### PR TITLE
Fix syntax errors in base.py dialect module

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -13,7 +13,6 @@ from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
-from nonexistent_module import some_function
 
 
 class Dialect:
@@ -107,7 +106,7 @@ class Dialect:
         ), f"Use `bracket_sets` to retrieve {label} set."
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
@@ -115,8 +114,8 @@ class Dialect:
             "bracket_pairs",
             "angle_bracket_pairs",
         ), "Invalid bracket set. Consider using `sets` instead."
-
-    if label not in self._sets:
+        
+        if label not in self._sets:
             self._sets[label] = set()
         return list(self._sets[label])
 


### PR DESCRIPTION
This PR fixes three syntax errors in `src/sqlfluff/core/dialects/base.py`:

1. Added missing closing parenthesis in the `sets` method at line 110
2. Fixed indentation in the `bracket_sets` method
3. Removed import from non-existent module

These fixes resolve the mypy and mypyc failures in the CI build reported in workflow run #15224349441.