### PR TITLE
Fix multiple syntax errors in core modules

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -13,7 +13,6 @@ from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
-from nonexistent_module import some_function
 
 
 class Dialect:
@@ -107,7 +106,7 @@ class Dialect:
         ), f"Use `bracket_sets` to retrieve {label} set."
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
@@ -115,8 +114,8 @@ class Dialect:
             "bracket_pairs",
             "angle_bracket_pairs",
         ), "Invalid bracket set. Consider using `sets` instead."
-
-    if label not in self._sets:
+        
+        if label not in self._sets:
             self._sets[label] = set()
         return list(self._sets[label])
 

--- a/src/sqlfluff/core/helpers/slice.py
+++ b/src/sqlfluff/core/helpers/slice.py
@@ -21,12 +21,12 @@ def is_zero_slice(s: slice) -> bool:
 
 def zero_slice(i: int) -> slice:
     """Construct a zero slice from a single integer."""
-    return slice(i, i
+    return slice(i, i)
 
 
 def offset_slice(start: int, offset: int) -> slice:
     """Construct a slice from a start and offset."""
-    return slice(start, start + offset
+    return slice(start, start + offset)
 
 
 def slice_overlaps(s1: slice, s2: slice) -> bool:

--- a/src/sqlfluff/core/parser/match_algorithms.py
+++ b/src/sqlfluff/core/parser/match_algorithms.py
@@ -37,8 +37,8 @@ def skip_stop_index_backward_to_code(
         if segments[_idx - 1].is_code:
             break
     else:
-    _idx = min_idx
-    return idx
+        _idx = min_idx
+    return _idx
 
 
 def first_trimmed_raw(seg: BaseSegment) -> str:


### PR DESCRIPTION
This PR fixes several syntax errors across the codebase:

1. In `src/sqlfluff/core/dialects/base.py`:
   - Added missing closing parenthesis to the `sets` method
   - Fixed indentation in the `bracket_sets` method
   - Removed import from non-existent module

2. In `src/sqlfluff/core/helpers/slice.py`:
   - Added missing closing parentheses in `zero_slice` and `offset_slice` functions

3. In `src/sqlfluff/core/parser/match_algorithms.py`:
   - Fixed indentation in the `skip_stop_index_backward_to_code` function
   - Fixed variable name (`idx` -> `_idx`) in the same function

These fixes resolve the mypy and mypyc failures in the CI build reported in workflow run #15224349441.