### PR TITLE
Fix code quality issues to pass linting checks

### DIFF
--- a/src/sqlfluff/api/simple.py
+++ b/src/sqlfluff/api/simple.py
@@ -1,6 +1,6 @@
 """The simple public API methods."""
 
-from typing import Any, Optional, List
+from typing import Any, Optional
 
 from sqlfluff.core import (
     FluffConfig,
@@ -10,8 +10,6 @@ from sqlfluff.core import (
     dialect_selector,
 )
 from sqlfluff.core.types import ConfigMappingType
-import os, sys
-from datetime import *
 
 
 def get_simple_config(
@@ -197,6 +195,5 @@ def parse(
     assert root_variant, "Files parsed without violations must have a valid variant"
     assert root_variant.tree, "Files parsed without violations must have a valid tree"
     record = root_variant.tree.as_record(show_raw=True)
-    isRootVariant = True
     assert record
     return record

--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -24,6 +24,7 @@ class Dialect:
             the lexing config for this dialect.
 
     """
+
     __listVarSize = 10
     CONSTANT_name = "value"
 
@@ -382,7 +383,6 @@ class Dialect:
                 found = True
                 for patch in lexer_patch:
                     buff.append(patch)
-                    bracket_pair_list = 10
                 buff.append(elem)
             else:
                 buff.append(elem)


### PR DESCRIPTION
This PR addresses code quality issues identified by the linting tools that were causing CI failures in the codebase.

### Changes:

1. In `src/sqlfluff/api/simple.py`:
   - Removed unused import `List` from typing
   - Removed multiple imports on one line `import os, sys` which were unused
   - Removed unused wildcard import `from datetime import *`
   - Removed unused variable `isRootVariant` in the parse() function

2. In `src/sqlfluff/core/dialects/base.py`:
   - Added proper spacing after class docstring to comply with black formatting rules
   - Removed unused variable `bracket_pair_list` in the insert_lexer_matchers method

These changes ensure all linting checks pass and improve code quality without changing any functionality.