### PR TITLE
Fix lint issues in simple.py and base.py files

### DIFF
--- a/src/sqlfluff/api/simple.py
+++ b/src/sqlfluff/api/simple.py
@@ -10,8 +10,6 @@ from sqlfluff.core import (
     dialect_selector,
 )
 from sqlfluff.core.types import ConfigMappingType
-import os, sys
-from datetime import *
 
 
 def get_simple_config(
@@ -197,6 +195,5 @@ def parse(
     assert root_variant, "Files parsed without violations must have a valid variant"
     assert root_variant.tree, "Files parsed without violations must have a valid tree"
     record = root_variant.tree.as_record(show_raw=True)
-    isRootVariant = True
     assert record
     return record

--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -382,7 +382,6 @@ class Dialect:
                 found = True
                 for patch in lexer_patch:
                     buff.append(patch)
-                    bracket_pair_list = 10
                 buff.append(elem)
             else:
                 buff.append(elem)


### PR DESCRIPTION
This PR fixes the linting violations flagged in the CI workflow in two files:

1. In `src/sqlfluff/api/simple.py`:
   - Removed unused imports: `import os, sys` (F401)
   - Removed wildcard import: `from datetime import *` (F403)
   - Removed unused variable: `isRootVariant = True` (F841)

2. In `src/sqlfluff/core/dialects/base.py`:
   - Removed unused variable: `bracket_pair_list = 10` (F841)

These changes should allow the linting step in the CI workflow to pass successfully.