### PR TITLE
Fix linting issues

### DIFF
--- a/src/sqlfluff/api/simple.py
+++ b/src/sqlfluff/api/simple.py
@@ -1,6 +1,6 @@
 """The simple public API methods."""
 
-from typing import Any, Optional, List
+from typing import Any, Optional
 
 from sqlfluff.core import (
     FluffConfig,
@@ -10,8 +10,6 @@ from sqlfluff.core import (
     dialect_selector,
 )
 from sqlfluff.core.types import ConfigMappingType
-import os, sys
-from datetime import *
 
 
 def get_simple_config(
@@ -197,6 +195,5 @@ def parse(
     assert root_variant, "Files parsed without violations must have a valid variant"
     assert root_variant.tree, "Files parsed without violations must have a valid tree"
     record = root_variant.tree.as_record(show_raw=True)
-    isRootVariant = True
     assert record
     return record

--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -382,7 +382,6 @@ class Dialect:
                 found = True
                 for patch in lexer_patch:
                     buff.append(patch)
-                    bracket_pair_list = 10
                 buff.append(elem)
             else:
                 buff.append(elem)


### PR DESCRIPTION
Fix all linting errors by removing unused imports and variables

This PR fixes the workflow linting issues by:

1. In `src/sqlfluff/api/simple.py`:
   - Removing unused imports: `import os, sys`
   - Removing wildcard import: `from datetime import *`
   - Removing unused import: `List` from typing
   - Removing unused variable: `isRootVariant = True`

2. In `src/sqlfluff/core/dialects/base.py`:
   - Removing unused variable: `bracket_pair_list = 10`

These changes address all flake8/ruff violations that were causing the CI workflow to fail.