### PR TITLE
Fix linting errors in simple.py

### DIFF
--- a/src/sqlfluff/api/simple.py
+++ b/src/sqlfluff/api/simple.py
@@ -1,6 +1,6 @@
 """The simple public API methods."""
 
-from typing import Any, Optional, List
+from typing import Any, Optional
 
 from sqlfluff.core import (
     FluffConfig,


### PR DESCRIPTION
## Description
Fixed linting errors in src/sqlfluff/api/simple.py that were causing the CI workflow to fail.

## Changes
- Removed unused `List` import from the typing module
- This fixes both the unused import (F401) and the import block formatting (I001) issues

## Testing
The change is minimal and primarily addresses code style violations. Running `ruff check` against the file shows that the linting errors are fixed.