### PR TITLE
Fix linting errors in simple.py

### DIFF
--- a/src/sqlfluff/api/simple.py
+++ b/src/sqlfluff/api/simple.py
@@ -1,6 +1,6 @@
 """The simple public API methods."""
 
-from typing import Any, Optional, List
+from typing import Any, Optional
 
 from sqlfluff.core import (
     FluffConfig,
@@ -10,9 +10,6 @@ from sqlfluff.core import (
     dialect_selector,
 )
 from sqlfluff.core.types import ConfigMappingType
-import os, sys
-from datetime import *
-
 
 def get_simple_config(
     dialect: Optional[str] = None,
@@ -197,6 +194,5 @@ def parse(
     assert root_variant, "Files parsed without violations must have a valid variant"
     assert root_variant.tree, "Files parsed without violations must have a valid tree"
     record = root_variant.tree.as_record(show_raw=True)
-    isRootVariant = True
     assert record
     return record


### PR DESCRIPTION
## Description
Fixed linting errors in src/sqlfluff/api/simple.py that were causing the CI workflow to fail.

## Changes
- Removed unused `List` import from the typing module
- Removed unused imports: `os`, `sys`, and wildcard import from `datetime`
- Removed the unused `isRootVariant` variable from the `parse` function
- Fixed import formatting issues

## Testing
The change addresses code style violations flagged by Ruff in the simple.py file:
- I001: Import block is un-sorted or un-formatted
- F401: Unused imports
- E401: Multiple imports on one line
- F403: Wildcard imports
- F841: Local variable assigned but never used