### PR TITLE
Fix: Remove unused bracket_pair_list variable

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -382,7 +382,6 @@ class Dialect:
                 found = True
                 for patch in lexer_patch:
                     buff.append(patch)
-                    bracket_pair_list = 10
                 buff.append(elem)
             else:
                 buff.append(elem)


### PR DESCRIPTION
This PR fixes the pre-commit CI pipeline failure by removing an unused variable `bracket_pair_list` in the `insert_lexer_matchers` method of the `Dialect` class.

The variable was assigned a value (10) but never used elsewhere in the code, which triggered F841 errors in both flake8 and ruff linters.

This change has no functional impact as the variable was never used in the first place.