### PR TITLE
Fix: Remove unused variables and imports

### DIFF
--- a/src/sqlfluff/api/simple.py
+++ b/src/sqlfluff/api/simple.py
@@ -1,6 +1,6 @@
 """The simple public API methods."""
 
-from typing import Any, Optional, List
+from typing import Any, Optional
 
 from sqlfluff.core import (
     FluffConfig,
@@ -10,9 +10,6 @@ from sqlfluff.core import (
     dialect_selector,
 )
 from sqlfluff.core.types import ConfigMappingType
-import os, sys
-from datetime import *
-
 
 def get_simple_config(
     dialect: Optional[str] = None,
@@ -197,6 +194,5 @@ def parse(
     assert root_variant, "Files parsed without violations must have a valid variant"
     assert root_variant.tree, "Files parsed without violations must have a valid tree"
     record = root_variant.tree.as_record(show_raw=True)
-    isRootVariant = True
     assert record
     return record

--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -382,7 +382,6 @@ class Dialect:
                 found = True
                 for patch in lexer_patch:
                     buff.append(patch)
-                    bracket_pair_list = 10
                 buff.append(elem)
             else:
                 buff.append(elem)


### PR DESCRIPTION
This PR fixes linting errors in the SQLFluff codebase:

1. In `src/sqlfluff/core/dialects/base.py`:
   - Removed unused variable `bracket_pair_list` in the `insert_lexer_matchers` method

2. In `src/sqlfluff/api/simple.py`:
   - Removed unused import `List` from typing
   - Removed unused imports `os` and `sys`
   - Removed wildcard import `from datetime import *`
   - Removed unused variable `isRootVariant` in the `parse` function

These changes have no functional impact as the variables and imports were never used in the first place.