### PR TITLE
Fix: Remove unused bracket_pair_list variable and add formatting

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -24,6 +24,7 @@ class Dialect:
             the lexing config for this dialect.
 
     """
+
     __listVarSize = 10
     CONSTANT_name = "value"
 
@@ -382,7 +383,6 @@ class Dialect:
                 found = True
                 for patch in lexer_patch:
                     buff.append(patch)
-                    bracket_pair_list = 10
                 buff.append(elem)
             else:
                 buff.append(elem)


### PR DESCRIPTION
This PR fixes a linting error in `src/sqlfluff/core/dialects/base.py`:

1. Removed an unused variable `bracket_pair_list` in the `insert_lexer_matchers` method
2. Added proper blank line after docstring per black formatter requirements

These changes have no functional impact as the variable was never used in the first place. The formatting change aligns with the project's code style requirements.