### PR TITLE
Fix: Remove unused bracket_pair_list variable with proper formatting

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -24,6 +24,7 @@ class Dialect:
             the lexing config for this dialect.
 
     """
+
     __listVarSize = 10
     CONSTANT_name = "value"
 
@@ -382,7 +383,6 @@ class Dialect:
                 found = True
                 for patch in lexer_patch:
                     buff.append(patch)
-                    bracket_pair_list = 10
                 buff.append(elem)
             else:
                 buff.append(elem)


### PR DESCRIPTION
This PR removes the unused variable `bracket_pair_list` in the `insert_lexer_matchers` method of the `Dialect` class and adds the proper formatting (blank line after docstring) required by the black formatter.

The variable was assigned a value (10) but never used elsewhere in the code, which triggered F841 errors in both flake8 and ruff linters.

This change has no functional impact as the variable was never used in the first place, and the formatting change aligns with the project's code style.