### PR TITLE
Fix syntax errors in base.py dialect class

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,16 +107,16 @@ class Dialect:
         ), f"Use `bracket_sets` to retrieve {label} set."
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
-    def bracket_sets(self, label: str) -> set[BracketPairTuple]:
+    def bracket_sets(self, label: str) -> list[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
         assert label in (
             "bracket_pairs",
             "angle_bracket_pairs",
         ), "Invalid bracket set. Consider using `sets` instead."
 
-    if label not in self._sets:
+        if label not in self._sets:
             self._sets[label] = set()
         return list(self._sets[label])
 


### PR DESCRIPTION
This PR fixes multiple syntax errors in the `src/sqlfluff/core/dialects/base.py` file:

1. Added a missing closing parenthesis in the `sets` method
2. Fixed indentation in the `bracket_sets` method that was causing a syntax error
3. Updated the return type annotation in `bracket_sets` method to correctly reflect that it returns a list, not a set

These syntax errors were causing the mypy and mypyc type checking commands to fail in the CI pipeline.