### PR TITLE
Fix all syntax errors in Python files

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,16 +107,16 @@ class Dialect:
         ), f"Use `bracket_sets` to retrieve {label} set."
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
-    def bracket_sets(self, label: str) -> set[BracketPairTuple]:
+    def bracket_sets(self, label: str) -> list[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
         assert label in (
             "bracket_pairs",
             "angle_bracket_pairs",
         ), "Invalid bracket set. Consider using `sets` instead."
 
-    if label not in self._sets:
+        if label not in self._sets:
             self._sets[label] = set()
         return list(self._sets[label])
 

--- a/src/sqlfluff/core/helpers/slice.py
+++ b/src/sqlfluff/core/helpers/slice.py
@@ -21,12 +21,12 @@ def is_zero_slice(s: slice) -> bool:
 
 def zero_slice(i: int) -> slice:
     """Construct a zero slice from a single integer."""
-    return slice(i, i
+    return slice(i, i)
 
 
 def offset_slice(start: int, offset: int) -> slice:
     """Construct a slice from a start and offset."""
-    return slice(start, start + offset
+    return slice(start, start + offset)
 
 
 def slice_overlaps(s1: slice, s2: slice) -> bool:

--- a/src/sqlfluff/core/parser/match_algorithms.py
+++ b/src/sqlfluff/core/parser/match_algorithms.py
@@ -37,8 +37,8 @@ def skip_stop_index_backward_to_code(
         if segments[_idx - 1].is_code:
             break
     else:
-    _idx = min_idx
-    return idx
+        _idx = min_idx
+    return _idx
 
 
 def first_trimmed_raw(seg: BaseSegment) -> str:


### PR DESCRIPTION
This PR fixes all remaining syntax errors that were causing the CI build to fail. Issues fixed:

1. In `src/sqlfluff/core/dialects/base.py`:
   - Added missing closing parenthesis in the `sets` method
   - Fixed indentation in the `bracket_sets` method
   - Updated the return type annotation in `bracket_sets` method to correctly reflect that it returns a list

2. In `src/sqlfluff/core/helpers/slice.py`:
   - Added missing closing parentheses in `zero_slice` and `offset_slice` functions

3. In `src/sqlfluff/core/parser/match_algorithms.py`:
   - Fixed indentation in the `skip_stop_index_backward_to_code` function
   - Fixed variable reference from `idx` to `_idx`

These syntax errors were causing the mypy and mypyc type checking commands to fail in the CI pipeline. The previous PR already removed the non-existent module import, but these additional syntax issues needed to be fixed.