### PR TITLE
Fix missing parenthesis in dialect base.py

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
         ), f"Use `bracket_sets` to retrieve {label} set."
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""


### PR DESCRIPTION
## Description
This PR fixes a syntax error in the SQLFluff dialect base class that was causing compilation failures.

The issue was a missing closing parenthesis in the `sets` method:
```python
# Before
return cast(set[str], self._sets[label]

# After (fixed)
return cast(set[str], self._sets[label])
```

This fix resolves the CI build and compilation failures in the mypy and mypyc checks.