### PR TITLE
Fix syntax error: Add missing closing parenthesis in Dialect.sets method

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
         ), f"Use `bracket_sets` to retrieve {label} set."
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""


### PR DESCRIPTION
## Description
This PR fixes a syntax error in the `sets` method of the `Dialect` class in `src/sqlfluff/core/dialects/base.py`. The issue was a missing closing parenthesis in the return statement, which was causing the mypy and mypyc tools to fail during CI build with the error "'(' was never closed [syntax]".

## Fix Details
- Added the missing closing parenthesis to the return statement in the `sets` method
- This allows the mypy and mypyc static type checkers to properly parse the file

## Root Cause
The CI pipeline failed because the mypy and mypyc tools were unable to parse the file due to the syntax error. While the Python interpreter might not immediately catch this issue if the method wasn't being called during tests, mypy and mypyc examine the entire code statically, which revealed the syntax error.