### PR TITLE
Fix linting issues in API simple.py

### DIFF
--- a/src/sqlfluff/api/simple.py
+++ b/src/sqlfluff/api/simple.py
@@ -1,6 +1,6 @@
 """The simple public API methods."""
 
-from typing import Any, Optional, List
+from typing import Any, Optional
 
 from sqlfluff.core import (
     FluffConfig,
@@ -10,8 +10,6 @@ from sqlfluff.core import (
     dialect_selector,
 )
 from sqlfluff.core.types import ConfigMappingType
-import os, sys
-from datetime import *
 
 
 def get_simple_config(
@@ -197,6 +195,5 @@ def parse(
     assert root_variant, "Files parsed without violations must have a valid variant"
     assert root_variant.tree, "Files parsed without violations must have a valid tree"
     record = root_variant.tree.as_record(show_raw=True)
-    isRootVariant = True
     assert record
     return record


### PR DESCRIPTION
## Description

This PR fixes linting issues in the API's simple.py file that were causing CI failures in the linting workflow. The changes include:

1. Removing the unused `List` import from `typing`
2. Removing unused imports: `os`, `sys`, and wildcard import from `datetime`
3. Removing an unused variable `isRootVariant` in the `parse()` function

These changes ensure the file passes all linting checks while maintaining its original functionality.

## Related Issues

- Fixes CI linting failures in the `cloudsmith-ci-features-linting.yml` workflow

## Tests

- The existing tests should continue to pass as no functional changes were made