### PR TITLE
Fix F841 linting error: Remove unused variable assignment

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -382,7 +382,6 @@ class Dialect:
                 found = True
                 for patch in lexer_patch:
                     buff.append(patch)
-                    bracket_pair_list = 10
                 buff.append(elem)
             else:
                 buff.append(elem)


### PR DESCRIPTION
## Description
This PR fixes a Ruff linting error (F841) by removing an unused variable assignment (`bracket_pair_list = 10`) in the `insert_lexer_matchers` method of the `Dialect` class.

## Issue
The GitHub workflow fails with the following error:
```
src/sqlfluff/core/dialects/base.py:385:21: F841 Local variable `bracket_pair_list` is assigned to but never used
```

## Solution
Remove the unused variable assignment while preserving the surrounding code logic. The variable is not used elsewhere in the method or class.

## Expected Outcome
The linting workflow should now pass successfully as the code will no longer have an unused variable.