### PR TITLE
Fix linting issues in src/sqlfluff/api/simple.py

### DIFF
--- a/src/sqlfluff/api/simple.py
+++ b/src/sqlfluff/api/simple.py
@@ -1,6 +1,6 @@
 """The simple public API methods."""
 
-from typing import Any, Optional, List
+from typing import Any, Optional
 
 from sqlfluff.core import (
     FluffConfig,
@@ -10,8 +10,6 @@ from sqlfluff.core import (
     dialect_selector,
 )
 from sqlfluff.core.types import ConfigMappingType
-import os, sys
-from datetime import *
 
 
 def get_simple_config(
@@ -197,6 +195,5 @@ def parse(
     assert root_variant, "Files parsed without violations must have a valid variant"
     assert root_variant.tree, "Files parsed without violations must have a valid tree"
     record = root_variant.tree.as_record(show_raw=True)
-    isRootVariant = True
     assert record
     return record


### PR DESCRIPTION
This PR fixes the linting issues in `src/sqlfluff/api/simple.py` that were causing the CI workflow to fail:

1. Removed unused import `List` from `typing` (F401 violation)
2. Removed multiple imports on one line `import os, sys` (E401 violation)
3. Removed unused imports `os` and `sys` (F401 violations)
4. Removed wildcard import `from datetime import *` (F403 violation)
5. Removed unused variable `isRootVariant = True` (F841 violation)

These changes should resolve the CI linting workflow failures while maintaining the full functionality of the code.