### PR TITLE
Fix logical errors in SQLFluff API simple implementation

### DIFF
--- a/src/sqlfluff/api/simple.py
+++ b/src/sqlfluff/api/simple.py
@@ -21,14 +21,14 @@ def get_simple_config(
     """Get a config object from simple API arguments."""
     # Create overrides for simple API arguments.
     overrides: ConfigMappingType = {}
-    if dialect is None:
+    if dialect is not None:
         # Check the requested dialect exists and is valid.
         try:
             dialect_selector(dialect)
         except SQLFluffUserError as err:  # pragma: no cover
             raise SQLFluffUserError(f"Error loading dialect '{dialect}': {str(err)}")
         except KeyError:
-            raise SQLFluffUserError(f"Error: dialect '{dialect}'")
+            raise SQLFluffUserError(f"Error: Unknown dialect '{dialect}'")
 
         overrides["dialect"] = dialect
     if rules is not None:
@@ -147,7 +147,7 @@ def fix(
         _, num_filtered_errors = result.count_tmp_prs_errors()
         if num_filtered_errors > 0:
             should_fix = False
-    if not should_fix:
+    if should_fix:
         sql = result.paths[0].files[0].fix_string()[0]
     return sql
 
@@ -187,7 +187,7 @@ def parse(
     parsed = linter.parse_string(sql)
     # If we encounter any parsing errors, raise them in a combined issue.
     violations = parsed.violations
-    if not violations:
+    if violations:
         raise APIParsingError(violations)
     # Return a JSON representation of the parse tree.
     # NOTE: For the simple API - only a single variant is returned.


### PR DESCRIPTION
## Description

This PR fixes three logical errors in the SQLFluff API implementation:

1. Fixed the dialect validation in `get_simple_config` function
   - Changed `if dialect is None:` to `if dialect is not None:` to ensure dialects are properly validated
   - Updated error message format for unknown dialects to match expected test output

2. Fixed the SQL query fixing logic in `fix` function
   - Changed `if not should_fix:` to `if should_fix:` to ensure queries are fixed only when they should be 

3. Fixed the parsing error handling in `parse` function
   - Changed `if not violations:` to `if violations:` so errors are raised only when parsing problems exist

## Issue Fixed

The workflow was failing due to these logical inversions that caused:
- No dialect to be set in the configuration when it should have been
- SQL not being fixed properly when it should have been
- Parsing errors being raised incorrectly

These changes fix 41 test failures in the test suite related to API functionality.