### PR TITLE
Fix syntax error: Add missing closing parenthesis in Dialect.sets method

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
         ), f"Use `bracket_sets` to retrieve {label} set."
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""


### PR DESCRIPTION
## Description

This PR fixes a syntax error in the `sets` method of the `Dialect` class that was causing mypy type checking failures in the CI workflow.

## Issue

The error was identified in the GitHub Actions workflow run:
- Workflow: `cloudsmith-ci-features-build-compilation.yml`
- Run ID: 15224349441

Error message:
```
.tox/mypy/lib/python3.10/site-packages/sqlfluff/core/dialects/base.py:110: error: '(' was never closed  [syntax]
Found 1 error in 1 file (errors prevented further checking)
```

## Fix

Added a missing closing parenthesis to the return statement in the `sets` method:
```python
return cast(set[str], self._sets[label])
```

This simple fix resolves the syntax error that was preventing mypy from validating the codebase.