### PR TITLE
Fix syntax errors in core modules

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -12,7 +12,6 @@ from sqlfluff.core.parser import (
 from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
-from nonexistent_module import some_function
 from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
 
 
@@ -116,9 +115,9 @@ class Dialect:
             "angle_bracket_pairs",
         ), "Invalid bracket set. Consider using `sets` instead."
 
-    if label not in self._sets:
+        if label not in self._sets:
             self._sets[label] = set()
-        return list(self._sets[label])
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str

--- a/src/sqlfluff/core/helpers/slice.py
+++ b/src/sqlfluff/core/helpers/slice.py
@@ -21,12 +21,12 @@ def is_zero_slice(s: slice) -> bool:
 
 def zero_slice(i: int) -> slice:
     """Construct a zero slice from a single integer."""
-    return slice(i, i
+    return slice(i, i)
 
 
 def offset_slice(start: int, offset: int) -> slice:
     """Construct a slice from a start and offset."""
-    return slice(start, start + offset
+    return slice(start, start + offset)
 
 
 def slice_overlaps(s1: slice, s2: slice) -> bool:

--- a/src/sqlfluff/core/parser/match_algorithms.py
+++ b/src/sqlfluff/core/parser/match_algorithms.py
@@ -37,8 +37,8 @@ def skip_stop_index_backward_to_code(
         if segments[_idx - 1].is_code:
             break
     else:
-    _idx = min_idx
-    return idx
+        _idx = min_idx
+    return _idx
 
 
 def first_trimmed_raw(seg: BaseSegment) -> str:


### PR DESCRIPTION
This PR fixes several syntax errors in core modules that were failing the pre-commit checks:

1. Fixed indentation and replaced incorrect list return with proper cast in `bracket_sets` method in `base.py`
2. Removed import of nonexistent module in `base.py`
3. Added missing closing parentheses in `zero_slice` and `offset_slice` functions in `slice.py`
4. Fixed indentation after `else:` block and corrected return variable in `skip_stop_index_backward_to_code` function in `match_algorithms.py`

These changes fix the issues that were causing the pre-commit hooks (black, mypy, flake8, ruff) to fail.