### PR TITLE
Fix syntax error: Add missing closing parenthesis in base.py

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
         ), f"Use `bracket_sets` to retrieve {label} set."
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""


### PR DESCRIPTION
This PR fixes a syntax error in `src/sqlfluff/core/dialects/base.py` by adding a missing closing parenthesis on line 110.

## Issue
The CI build was failing because of a syntax error detected by the mypy type checker and mypyc compiler:
```
.tox/mypy/lib/python3.10/site-packages/sqlfluff/core/dialects/base.py:110: error: '(' was never closed [syntax]
```

## Fix
Added the missing closing parenthesis to the `cast()` function call:
```python
# Before
return cast(set[str], self._sets[label]

# After
return cast(set[str], self._sets[label])
```

This simple fix resolves the syntax error and allows the CI build to proceed.