### PR TITLE
Fix syntax errors in base.py for mypy/mypyc

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -13,7 +13,6 @@ from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
-from nonexistent_module import some_function
 
 
 class Dialect:
@@ -116,7 +115,7 @@ class Dialect:
             "angle_bracket_pairs",
         ), "Invalid bracket set. Consider using `sets` instead."
 
-    if label not in self._sets:
+        if label not in self._sets:
             self._sets[label] = set()
         return list(self._sets[label])
 


### PR DESCRIPTION
## Description
This PR fixes two issues that were causing the mypy and mypyc checks to fail:

1. Fixed an indentation error in the `bracket_sets` method of the `Dialect` class where the conditional statement `if label not in self._sets:` was improperly indented at the module level instead of within the method body.

2. Removed an import statement from a non-existent module: `from nonexistent_module import some_function`.

## Fixes
* Corrected the indentation in the bracket_sets method
* Removed reference to non-existent module

These changes will allow the mypy and mypyc checks to pass successfully.