### PR TITLE
Fix syntax errors in Python files

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -13,6 +13,7 @@ from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
+
 # Import removed during fix
 
 
@@ -107,7 +108,7 @@ class Dialect:
         ), f"Use `bracket_sets` to retrieve {label} set."
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label])))
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
@@ -118,7 +119,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return list(self._sets[label])
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str

--- a/src/sqlfluff/core/helpers/slice.py
+++ b/src/sqlfluff/core/helpers/slice.py
@@ -21,12 +21,12 @@ def is_zero_slice(s: slice) -> bool:
 
 def zero_slice(i: int) -> slice:
     """Construct a zero slice from a single integer."""
-    return slice(i, i))
+    return slice(i, i)
 
 
 def offset_slice(start: int, offset: int) -> slice:
     """Construct a slice from a start and offset."""
-    return slice(start, start + offset))
+    return slice(start, start + offset)
 
 
 def slice_overlaps(s1: slice, s2: slice) -> bool:

--- a/src/sqlfluff/core/parser/match_algorithms.py
+++ b/src/sqlfluff/core/parser/match_algorithms.py
@@ -37,8 +37,8 @@ def skip_stop_index_backward_to_code(
         if segments[_idx - 1].is_code:
             break
     else:
-    _idx = min_idx
-    return idx
+        _idx = min_idx
+    return _idx
 
 
 def first_trimmed_raw(seg: BaseSegment) -> str:


### PR DESCRIPTION
This PR fixes several syntax errors that were causing the pre-commit checks to fail:

1. Removed extra parentheses in `src/sqlfluff/core/dialects/base.py` (line 110)
2. Removed extra parenthesis in `src/sqlfluff/core/helpers/slice.py` (line 24)
3. Removed extra parenthesis in `src/sqlfluff/core/helpers/slice.py` (line 29)
4. Fixed indentation error in `src/sqlfluff/core/parser/match_algorithms.py` (line 40)
5. Fixed variable name reference in `src/sqlfluff/core/parser/match_algorithms.py` (line 41)
6. Fixed type casting in `src/sqlfluff/core/dialects/base.py` bracket_sets method

All pre-commit checks now pass successfully.