### PR TITLE
Fix: Add blank line after imports to comply with Black formatting

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -13,6 +13,7 @@ from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
+
 # Import removed during fix
 
 


### PR DESCRIPTION
This PR fixes the Black formatting issue by adding a blank line between imports and the first comment in `src/sqlfluff/core/dialects/base.py`.

## Problem
The CI workflow was failing because Black was automatically modifying the file during pre-commit checks, which is configured to fail if any files are modified.

## Solution
Added a blank line between the import statements and the first comment to comply with Black's formatting rules. This prevents Black from automatically modifying the file during pre-commit checks.

## Testing
Verified that the pre-commit check passes without modifying the file by running:
```
pre-commit run --files src/sqlfluff/core/dialects/base.py
```