### PR TITLE
Fix PEP 8 style violation by adding blank line after imports

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -13,6 +13,7 @@ from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
+
 # Import removed during fix
 
 


### PR DESCRIPTION
This PR fixes the GitHub Actions workflow failure by adding a blank line after the import statement in `src/sqlfluff/core/dialects/base.py` to comply with PEP 8 style guidelines enforced by the black formatter.

The change adds a blank line between the import statement and the comment to ensure proper code formatting according to PEP 8 standards.

Before:
```python
from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
# Import removed during fix
```

After:
```python
from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType

# Import removed during fix
```

This change ensures that the pre-commit black formatter will no longer modify the file during CI checks.