### PR TITLE
Fix: Add blank line after imports to comply with Black formatting

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -13,6 +13,7 @@ from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
+
 # Import removed during fix
 
 


### PR DESCRIPTION
This PR fixes the issue where the Black formatter was automatically adding a blank line after import statements in `src/sqlfluff/core/dialects/base.py`, which was causing the pre-commit hook to fail.

## Changes
- Added a blank line between the import statements and the comment to comply with Black's formatting rules
- This prevents Black from automatically adding the line during pre-commit checks

## Root Cause
Black's formatting rules require a blank line between import statements and other code (including comments), which is why it automatically added this blank line during pre-commit checks. By adding this blank line in the source code, we prevent Black from making changes during the pre-commit process, allowing the workflow to pass.