### PR TITLE
Fix PEP 8 style violation by adding blank line after imports

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -13,6 +13,7 @@ from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
+
 # Import removed during fix
 
 


### PR DESCRIPTION
This PR fixes the GitHub Actions workflow failure by ensuring the code follows PEP 8 style guidelines.

## Changes
- Added a blank line after imports in `src/sqlfluff/core/dialects/base.py` to comply with PEP 8 style guidelines enforced by the black formatter.

## Root Cause
The black formatter was detecting a PEP 8 style violation where there was no blank line between the import statements and the following comment. By adding this blank line manually, we ensure that the black formatter no longer needs to make changes during pre-commit checks.