### PR TITLE
Fix missing docstring in src/test.py

### DIFF
--- a/src/test.py
+++ b/src/test.py
@@ -1,0 +1,9 @@
+"""Test module for demonstration purposes."""
+
+def test_function():
+    """Test function that returns a string.
+    
+    Returns:
+        str: A test string
+    """
+    return "This is a test function"


### PR DESCRIPTION
This PR adds the missing docstring to `src/test.py` which was causing the ruff linter to fail with error D100 (Missing docstring in public module).

The fix adds a proper module-level docstring and a function-level docstring to comply with the project's linting rules.

Fixes the workflow failure in run ID: 15501840752