### PR TITLE
Add *.bak files to .gitignore to prevent backup files from being committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/packages.yml
 # Emacs
 *~
 
+# Backup files
+*.bak
+
 # Mypyc outputs
 *.pyd
 *.so


### PR DESCRIPTION
This PR adds `*.bak` files to the `.gitignore` file to prevent backup files from being committed to the repository in the future.

The build was failing because the file `src/sqlfluff/core/dialects/base.py.bak` was missing a newline character at the end of the file, which violated the project's code style requirements enforced by the pre-commit hook `end-of-file-fixer`.

While the file has already been deleted in the latest commit, this PR adds a preventive measure to ensure that backup files (which typically shouldn't be in version control) won't be accidentally committed in the future.