### PR TITLE
Fix pre-commit issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,4 +94,3 @@ repos:
       - id: codespell
         exclude: (?x)^(test/fixtures/.*|pyproject.toml)$
         additional_dependencies: [tomli]
-

--- a/src/test.py
+++ b/src/test.py
@@ -1,0 +1,2 @@
+"""Test module for demonstration purposes."""
+print("Hello, world!")


### PR DESCRIPTION
This PR fixes two pre-commit issues:

1. Added a module-level docstring to `src/test.py` to fix the ruff D100 error
2. Fixed the trailing newline in `.pre-commit-config.yaml` to ensure there's exactly one newline at the end of the file

Both issues were causing the pre-commit workflow to fail. The changes have been tested locally with pre-commit hooks and all checks now pass.