### PR TITLE
Fix: Add pre-commit clean step to prevent issues with deleted files

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Run pre-commit hooks
         run: |
           set -o pipefail
+          # Clean pre-commit cache to prevent issues with deleted files
+          pre-commit clean
           pre-commit gc
           pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
       - name: Convert Raw Log to Checkstyle format (launch action)


### PR DESCRIPTION
This PR fixes the CI pipeline failure by adding a `pre-commit clean` step before running the hooks.

The issue was caused by the pre-commit cache containing references to a file (`test/core/helpers/mock_test.py`) that no longer exists in the repository. By cleaning the cache before running the hooks, we ensure that pre-commit only processes files that actually exist in the current repository state.

This is a minimal change that addresses the root cause without modifying any other aspects of the workflow.