### PR TITLE
Fix formatting issues in patch file

### DIFF
--- a/0001-Fix-code-quality-issues-add-newlines-at-end-of-files.patch
+++ b/0001-Fix-code-quality-issues-add-newlines-at-end-of-files.patch
@@ -14,9 +14,9 @@ index 81923eb14..9bb4fa736 100644
 --- a/src/sqlfluff/core/dialects/base.py.bak.bak
 +++ b/src/sqlfluff/core/dialects/base.py.bak.bak
 @@ -394,4 +394,4 @@ class Dialect:
- 
-     def get_root_segment(self) -> Union[type[BaseSegment], Matchable]:
-         """Get the root segment of the dialect."""
+
+    def get_root_segment(self) -> Union[type[BaseSegment], Matchable]:
+        """Get the root segment of the dialect."""
 -        return self.ref(self.root_segment_name)
 \ No newline at end of file
 +        return self.ref(self.root_segment_name)
@@ -26,13 +26,12 @@ index 5677c6ca6..2e3c7dc39 100644
 +++ b/src/test.py
 @@ -1,5 +1,6 @@
  """Test module docstring."""
- 
-+
+
+
  def test_function():
      """Test function docstring."""
 -    return True
 \ No newline at end of file
 +    return True
--- 
+--
 2.47.1
-


### PR DESCRIPTION
This PR fixes the formatting issues in the patch file that were causing the pre-commit hooks to fail.

The following changes were made:
1. Removed trailing whitespace in the patch file
2. Added a proper newline at the end of the file

These changes ensure the patch file passes the pre-commit hooks that were previously failing.