### PR TITLE
Fix trailing whitespace in fix-eof-newline.patch.bak

### DIFF
--- a/fix-eof-newline.patch.bak
+++ b/fix-eof-newline.patch.bak
@@ -3,7 +3,7 @@ index 2e9571cb8..478fb861e 100644
 --- a/src/test.py.bak
 +++ b/src/test.py.bak
 @@ -6,4 +6,4 @@ This module contains test utilities and functions.
- 
+
  def test_function():
      """Test function docstring."""
 -    return True

--- a/fix-eof-newline.patch.bak.bak
+++ b/fix-eof-newline.patch.bak.bak
@@ -1,0 +1,11 @@
+diff --git a/src/test.py.bak b/src/test.py.bak
+index 2e9571cb8..478fb861e 100644
+--- a/src/test.py.bak
++++ b/src/test.py.bak
+@@ -6,4 +6,4 @@ This module contains test utilities and functions.
+ 
+ def test_function():
+     """Test function docstring."""
+-    return True
+\ No newline at end of file
++    return True


### PR DESCRIPTION
This PR fixes the trailing whitespace issue in fix-eof-newline.patch.bak that was causing the pre-commit workflow to fail. The trailing whitespace in line 3 has been removed.