### PR TITLE
Exclude .patch and .patch.bak files from trailing-whitespace hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,9 @@ repos:
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/macro_in_macro.sql|
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/last_day.sql|
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/dbt_utils_0.8.0/last_day.sql|
-            test/fixtures/linter/sqlfluffignore/
+            test/fixtures/linter/sqlfluffignore/|
+            .*\.patch|
+            .*\.patch\.bak
           )$
   - repo: https://github.com/psf/black
     rev: 25.1.0


### PR DESCRIPTION
This PR fixes the failing pre-commit CI workflow by excluding `.patch` and `.patch.bak` files from the trailing-whitespace hook.

## Problem
The pre-commit hook `trailing-whitespace` was detecting and automatically fixing trailing whitespace in `.patch.bak` files, which contain metadata about line endings (like "No newline at end of file"). This is part of the patch format, not actual trailing whitespace that should be removed.

## Solution
Added `.patch` and `.patch.bak` files to the exclusion list for the `trailing-whitespace` hook in the `.pre-commit-config.yaml` file.

## Testing
Verified locally that the pre-commit hook now skips these files when run with `pre-commit run trailing-whitespace --files 0001-Fix-code-quality-issues-add-newlines-at-end-of-files.patch.bak`.