### PR TITLE
Fix pre-commit issues in fix-eof-newline.patch

### DIFF
--- a/fix-eof-newline.patch
+++ b/fix-eof-newline.patch
@@ -3,9 +3,9 @@ index 2e9571cb8..478fb861e 100644
 --- a/src/test.py.bak
 +++ b/src/test.py.bak
 @@ -6,4 +6,4 @@ This module contains test utilities and functions.
- 
- def test_function():
-     """Test function docstring."""
+
+def test_function():
+    """Test function docstring."""
 -    return True
 \ No newline at end of file
 +    return True


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by addressing two issues in the fix-eof-newline.patch file:

1. Removed trailing whitespace
2. Added a newline at the end of the file

The pre-commit workflow was failing because both the `trailing-whitespace` and `end-of-file-fixer` hooks detected issues in the patch file. In CI environments, when pre-commit hooks modify files, the workflow fails by design to ensure developers fix these issues locally before pushing code.

These changes ensure the file passes all pre-commit checks, allowing the workflow to pass successfully.