### PR TITLE
Fix: Add missing newline at end of fix-eof-newline.patch

### DIFF
--- a/fix-eof-newline.patch
+++ b/fix-eof-newline.patch
@@ -9,3 +9,4 @@ def test_function():
 -    return True
 \ No newline at end of file
 +    return True
+


### PR DESCRIPTION
This PR fixes the GitHub Actions workflow failure by adding a missing newline at the end of the `fix-eof-newline.patch` file.

## Root Cause
The `fix-eof-newline.patch` file itself was missing a newline at the end, which triggered the `end-of-file-fixer` pre-commit hook to modify the file. Ironically, this patch file is meant to demonstrate fixing a missing newline in another file, but it had the same issue itself.

## Solution
Added the missing newline at the end of the `fix-eof-newline.patch` file to ensure it passes the pre-commit checks.