### PR TITLE
Fix pre-commit workflow by excluding fix-eof-newline.patch files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,8 @@ repos:
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/macro_in_macro.sql|
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/(dbt_utils_0.8.0/)?last_day.sql|
             test/fixtures/linter/indentation_errors.sql|
-            test/fixtures/templater/jinja_d_roundtrip/test.sql
+            test/fixtures/templater/jinja_d_roundtrip/test.sql|
+            fix-eof-newline\.patch.*
           )$
       - id: trailing-whitespace
         exclude: |


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by excluding the `fix-eof-newline.patch*` files from the end-of-file-fixer hook.

These files are intentionally demonstrating end-of-line newline issues and should be excluded from the automatic fixing.

The change adds a pattern to the exclude list in `.pre-commit-config.yaml` to ignore these specific patch files.