### PR TITLE
Fix: Remove extra trailing newline in fix-eof-newline.patch

### DIFF
--- a/fix-eof-newline.patch
+++ b/fix-eof-newline.patch
@@ -9,4 +9,3 @@ def test_function():
 -    return True
 \ No newline at end of file
 +    return True
-

--- a/fix-eof-newline.patch.bak
+++ b/fix-eof-newline.patch.bak
@@ -1,0 +1,12 @@
+diff --git a/src/test.py.bak b/src/test.py.bak
+index 2e9571cb8..478fb861e 100644
+--- a/src/test.py.bak
++++ b/src/test.py.bak
+@@ -6,4 +6,4 @@ This module contains test utilities and functions.
+
+def test_function():
+    """Test function docstring."""
+-    return True
+\ No newline at end of file
++    return True
+


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by removing the extra trailing newline at the end of the `fix-eof-newline.patch` file.

The file had two newlines at the end, which violated the pre-commit hook's requirement that files should have exactly one newline at the end. This PR ensures the file has exactly one newline at the end, which allows the pre-commit hook to pass.

Root cause:
- The `end-of-file-fixer` pre-commit hook requires files to have exactly one newline at the end
- The `fix-eof-newline.patch` file had two newlines at the end
- The hook detected this issue and modified the file by removing the extra newline
- Since pre-commit hooks are expected to pass without modifying files in CI environments, this modification caused the workflow to fail