### PR TITLE
Fix type error in bracket_sets method

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -13,6 +13,7 @@ from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
+
 # Import removed during fix
 
 
@@ -118,7 +119,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return list(self._sets[label])
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str

--- a/src/sqlfluff/core/dialects/base.py.bak
+++ b/src/sqlfluff/core/dialects/base.py.bak
@@ -107,7 +107,7 @@ class Dialect:
         ), f"Use `bracket_sets` to retrieve {label} set."
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]))
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return list(self._sets[label])
+        return self._sets[label]
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
This PR fixes a type error in the `bracket_sets` method in `src/sqlfluff/core/dialects/base.py`.

## Issue
The method was defined with a return type annotation of `set[BracketPairTuple]`, but was actually returning `list(self._sets[label])`, which converts the set to a list before returning it. This caused a type mismatch error detected by mypy:

```
Incompatible return value type (got "list[str | tuple[str, str, str, bool]]", expected "set[tuple[str, str, str, bool]]")  [return-value]
```

## Fix
Changed the implementation to return the set directly with proper type casting:
```python
return cast(set[BracketPairTuple], self._sets[label])
```

This ensures the return type matches the method's type annotation and resolves the mypy error.