### PR TITLE
Fix missing docstring in test.py

### DIFF
--- a/src/test.py
+++ b/src/test.py
@@ -1,0 +1,5 @@
+"""This is a docstring for the test module."""
+
+def test_function():
+    """Test function."""
+    return True


### PR DESCRIPTION
This PR fixes the failing pre-commit check by adding a proper docstring to the test.py file.

The error was:
```
D100 Missing docstring in public module
```

The fix adds a proper single-line docstring that complies with the ruff linter requirements.