### PR TITLE
Fix missing newline in .pre-commit-config.yaml.bak.bak

### DIFF
--- a/.pre-commit-config.yaml.bak.bak
+++ b/.pre-commit-config.yaml.bak.bak
@@ -94,4 +94,3 @@ repos:
       - id: codespell
         exclude: (?x)^(test/fixtures/.*|pyproject.toml)$
         additional_dependencies: [tomli]
-


### PR DESCRIPTION
This PR fixes the GitHub Actions workflow failure by ensuring the proper newline character at the end of the `.pre-commit-config.yaml.bak.bak` file.

The pre-commit hook `end-of-file-fixer` was failing because the file had an incorrect end-of-file format. This fix ensures the file ends with exactly one newline character, which is the standard required by the pre-commit hook.

The change is minimal and only affects the end-of-file formatting, with no functional changes to the content of the file.