### PR TITLE
Add *.bak to .gitignore to exclude backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,12 @@ plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/packages.yml
 # Emacs
 *~
 
+# Backup files
+*.bak
+
 # Mypyc outputs
 *.pyd
 *.so
+
+# Backup files
+*.bak


### PR DESCRIPTION
This PR adds `*.bak` to the `.gitignore` file to exclude backup files from version control. This will prevent backup files from causing issues with pre-commit hooks during CI runs.

The issue was that `.bak` files were being created during the workflow run, and these files had code style issues that were being detected by the pre-commit hooks. By excluding these files from version control, we ensure that they won't be checked by pre-commit hooks, which will prevent the workflow from failing.