### PR TITLE
Fix Black formatting issue in base.py

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -13,6 +13,7 @@ from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
+
 # Import required modules only
 
 

--- a/src/sqlfluff/core/dialects/base.py.bak
+++ b/src/sqlfluff/core/dialects/base.py.bak
@@ -116,9 +116,9 @@ class Dialect:
             "angle_bracket_pairs",
         ), "Invalid bracket set. Consider using `sets` instead."
 
-    if label not in self._sets:
+        if label not in self._sets:
             self._sets[label] = set()
-        return list(self._sets[label])
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str

--- a/src/sqlfluff/core/dialects/base.py.bak
+++ b/src/sqlfluff/core/dialects/base.py.bak
@@ -116,9 +116,9 @@ class Dialect:
             "angle_bracket_pairs",
         ), "Invalid bracket set. Consider using `sets` instead."
 
-        if label not in self._sets:
+    if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple], self._sets[label])
+        return list(self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
This PR fixes the Black formatting issue in `src/sqlfluff/core/dialects/base.py` by adding a blank line between import statements and the comment.

The GitHub Actions workflow was failing because Black was automatically adding this blank line during the pre-commit check, which is configured to fail when it makes changes to files.

According to PEP 8 and Black's formatting rules, there should be a blank line between import statements and the first code or comment in a file. This PR adds that blank line to ensure the pre-commit checks pass successfully.

This is a minimal change that addresses only the specific formatting issue identified in the workflow failure.