### PR TITLE
Fix: Add blank line after imports in base.py to comply with PEP 8

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -13,6 +13,7 @@ from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
+
 # Import required modules only
 
 


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by adding a blank line after the import statements in `src/sqlfluff/core/dialects/base.py` to comply with PEP 8 style guidelines.

The Black formatter was automatically adding this blank line during pre-commit checks, causing the workflow to fail. By adding the blank line in our code, we ensure that Black won't need to modify the file during pre-commit checks.

**Changes made:**
- Added a blank line between the import statements and the comment "# Import required modules only" to comply with PEP 8, which recommends two blank lines before top-level class definitions.