### PR TITLE
Fix: Remove invalid --files-to-exclude parameter from pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,8 +29,8 @@ jobs:
         run: |
           set -o pipefail
           pre-commit gc
-          # Skip pre-commit on mock_test.py to avoid failures
-          pre-commit run --show-diff-on-failure --color=always --all-files --files-to-exclude="test/core/helpers/mock_test.py" | tee ${RAW_LOG}
+          # Run pre-commit on all files
+          pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5
         if: ${{ failure() }}

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -1,0 +1,54 @@
+---
+name: pre-commit
+on:
+  pull_request:
+  push:
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    env:
+      RAW_LOG: pre-commit.log
+      CS_XML: pre-commit.xml
+      SKIP: no-commit-to-branch
+    steps:
+      - run: sudo apt-get update && sudo apt-get install cppcheck
+        if: false
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        if: false
+        with:
+          cache: pip
+          python-version: 3.12.1
+      - run: python -m pip install pre-commit
+      - uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/pre-commit/
+          key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml')
+            }}
+      - name: Run pre-commit hooks
+        run: |
+          set -o pipefail
+          pre-commit gc
+          # Skip pre-commit on mock_test.py to avoid failures
+          pre-commit run --show-diff-on-failure --color=always --all-files --files-to-exclude="test/core/helpers/mock_test.py" | tee ${RAW_LOG}
+      - name: Convert Raw Log to Checkstyle format (launch action)
+        uses: mdeweerd/logToCheckStyle@v2024.3.5
+        if: ${{ failure() }}
+        with:
+          in: ${{ env.RAW_LOG }}
+          out: ${{ env.CS_XML }}
+      - uses: actions/cache/save@v4
+        if: ${{ ! cancelled() }}
+        with:
+          path: ~/.cache/pre-commit/
+          key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml')
+            }}
+      - name: Provide log as artifact
+        uses: actions/upload-artifact@v4
+        if: ${{ ! cancelled() }}
+        with:
+          name: precommit-logs
+          path: |
+            ${{ env.RAW_LOG }}
+            ${{ env.CS_XML }}
+          retention-days: 2


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by removing the invalid `--files-to-exclude` parameter.

## Problem
The pre-commit workflow was failing because it was using an invalid command-line option `--files-to-exclude` that is not supported by the pre-commit tool. Additionally, the workflow was trying to exclude a file that doesn't exist in the repository.

## Solution
Removed the unsupported parameter and updated the comment to reflect that pre-commit will run on all files.

## Testing
Validated locally that the pre-commit command runs successfully without the invalid parameter.