### PR TITLE
Fix pre-commit workflow by removing invalid --files-to-exclude parameter

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,8 +29,8 @@ jobs:
         run: |
           set -o pipefail
           pre-commit gc
-          # Skip pre-commit on mock_test.py to avoid failures
-          pre-commit run --show-diff-on-failure --color=always --all-files --files-to-exclude="test/core/helpers/mock_test.py" | tee ${RAW_LOG}
+          # Run pre-commit on all files
+          pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5
         if: ${{ failure() }}


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by removing the invalid `--files-to-exclude` parameter.

## Issue
The workflow was failing because:
1. The `--files-to-exclude` parameter is not a valid option for the `pre-commit run` command
2. The file being excluded (`test/core/helpers/mock_test.py`) does not exist in the repository

## Solution
- Removed the invalid parameter and updated the comment to reflect that pre-commit runs on all files
- This ensures the workflow will run successfully without trying to exclude non-existent files

## Validation
- Confirmed that pre-commit does not support a `--files-to-exclude` parameter
- Verified that the file `test/core/helpers/mock_test.py` doesn't exist in the repository
- The proper way to exclude files in pre-commit is through the `.pre-commit-config.yaml` file, not command-line arguments