### PR TITLE
Fix: Use git ls-files to prevent phantom file issues in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,8 +29,8 @@ jobs:
         run: |
           set -o pipefail
           pre-commit gc
-          # Run pre-commit on all files
-          pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
+          # Run pre-commit only on tracked files
+          pre-commit run --show-diff-on-failure --color=always --files $(git ls-files) | tee ${RAW_LOG}
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5
         if: ${{ failure() }}


### PR DESCRIPTION
This PR fixes the issue with phantom files in the pre-commit workflow with a minimal change.

## Problem
The pre-commit hooks were attempting to modify a file (test/core/helpers/mock_test.py) that doesn't actually exist in the repository, causing the workflow to fail with linting errors.

## Solution
Modified the pre-commit run command to only process tracked files instead of all files by changing:
```diff
- # Run pre-commit on all files
- pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
+ # Run pre-commit only on tracked files
+ pre-commit run --show-diff-on-failure --color=always --files $(git ls-files) | tee ${RAW_LOG}
```

This ensures that pre-commit only runs on files that actually exist in the repository and prevents phantom files from causing workflow failures.