### PR TITLE
Fix pre-commit workflow by removing invalid --no-fix flag

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,7 +25,7 @@ jobs:
           path: ~/.cache/pre-commit/
           key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml')
             }}
-        # Using --no-fix flag to ensure pre-commit only reports issues without modifying files
+        # Pre-commit in CI environments runs in check mode by default (doesn't modify files)
         # This prevents workflow failures due to file modifications in CI
       - name: Run pre-commit hooks
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -32,7 +32,7 @@ jobs:
           set -o pipefail
           pre-commit gc
           # Run pre-commit on all files in check mode (don't modify files)
-          pre-commit run --show-diff-on-failure --color=always --all-files --no-fix | tee ${RAW_LOG}
+          pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5
         if: ${{ failure() }}


### PR DESCRIPTION
This PR fixes the pre-commit workflow by removing the invalid `--no-fix` flag from the pre-commit run command.

## Issue
The workflow was failing with the error: `pre-commit: error: unrecognized arguments: --no-fix`

## Solution
- Removed the `--no-fix` flag from the pre-commit run command
- Updated the comment to clarify that pre-commit in CI environments runs in check mode by default

Pre-commit's default behavior when run with `--all-files` is to check files without modifying them, so the `--no-fix` flag was unnecessary and causing the workflow to fail.