### PR TITLE
Fix: Remove duplicate exclude keys in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,10 +39,6 @@ repos:
           (?x)^(
             test/core/helpers/mock_test.py
           )$
-        exclude: |
-          (?x)^(
-            test/core/helpers/mock_test.py
-          )$
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.14.1
     hooks:
@@ -83,10 +79,6 @@ repos:
           (?x)^(
             test/core/helpers/mock_test.py
           )$
-        exclude: |
-          (?x)^(
-            test/core/helpers/mock_test.py
-          )$
   - repo: https://github.com/pycqa/doc8
     rev: v1.1.2
     hooks:
@@ -103,10 +95,6 @@ repos:
     rev: "v0.9.3"
     hooks:
       - id: ruff
-        exclude: |
-          (?x)^(
-            test/core/helpers/mock_test.py
-          )$
         exclude: |
           (?x)^(
             test/core/helpers/mock_test.py

--- a/.pre-commit-config.yaml.bak
+++ b/.pre-commit-config.yaml.bak
@@ -39,10 +39,6 @@ repos:
           (?x)^(
             test/core/helpers/mock_test.py
           )$
-        exclude: |
-          (?x)^(
-            test/core/helpers/mock_test.py
-          )$
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.14.1
     hooks:
@@ -83,10 +79,6 @@ repos:
           (?x)^(
             test/core/helpers/mock_test.py
           )$
-        exclude: |
-          (?x)^(
-            test/core/helpers/mock_test.py
-          )$
   - repo: https://github.com/pycqa/doc8
     rev: v1.1.2
     hooks:
@@ -103,6 +95,10 @@ repos:
     rev: "v0.9.3"
     hooks:
       - id: ruff
+        exclude: |
+          (?x)^(
+            test/core/helpers/mock_test.py
+          )$
         exclude: |
           (?x)^(
             test/core/helpers/mock_test.py


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by removing duplicate `exclude` keys in the `.pre-commit-config.yaml` file.

The issue was that there were duplicate `exclude` keys with identical content in three hook configurations:
1. In the black hook configuration
2. In the flake8 hook configuration
3. In the ruff hook configuration

This fix removes the duplicate keys while preserving the functionality, allowing the pre-commit workflow to run successfully.

Fixes #N/A