### PR TITLE
Fix: Remove invalid --files-to-exclude argument from pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,8 +30,8 @@ jobs:
           # Clean pre-commit cache to remove phantom files
           pre-commit clean
           pre-commit gc
-          # Run pre-commit on all files, excluding the phantom file
-          pre-commit run --show-diff-on-failure --color=always --all-files --files-to-exclude="test/core/helpers/mock_test.py" | tee ${RAW_LOG}
+          # Run pre-commit on all files except the phantom file
+          find . -type f -not -path "./test/core/helpers/mock_test.py" | xargs pre-commit run --show-diff-on-failure --color=always --files | tee ${RAW_LOG}
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5
         if: ${{ failure() }}

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -27,9 +27,11 @@ jobs:
       - name: Run pre-commit hooks
         run: |
           set -o pipefail
+          # Clean pre-commit cache to remove phantom files
+          pre-commit clean
           pre-commit gc
           # Run pre-commit on all files, excluding the phantom file
-          pre-commit run --show-diff-on-failure --color=always --all-files --files-to-exclude="test/core/helpers/mock_test.py" | tee ${RAW_LOG}
+          pre-commit run --show-diff-on-failure --color=always --all-files --files test/core/helpers/mock_test.py --exclude | tee ${RAW_LOG}
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5
         if: ${{ failure() }}

--- a/pre-commit.log
+++ b/pre-commit.log
@@ -1,0 +1,45 @@
+[INFO][m Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
+[INFO][m Initializing environment for https://github.com/psf/black.
+[INFO][m Initializing environment for https://github.com/pre-commit/mirrors-mypy.
+[INFO][m Initializing environment for https://github.com/pre-commit/mirrors-mypy:types-toml,types-chardet,types-colorama,types-pyyaml,types-regex,types-tqdm,jinja2,pathspec,pytest,click,platformdirs.
+[INFO][m Initializing environment for https://github.com/pycqa/flake8.
+[INFO][m Initializing environment for https://github.com/pycqa/flake8:flake8-black>=0.3.6.
+[INFO][m Initializing environment for https://github.com/pycqa/doc8.
+[INFO][m Initializing environment for https://github.com/adrienverge/yamllint.git.
+[INFO][m Initializing environment for https://github.com/charliermarsh/ruff-pre-commit.
+[INFO][m Initializing environment for https://github.com/codespell-project/codespell.
+[INFO][m Initializing environment for https://github.com/codespell-project/codespell:tomli.
+[INFO][m Installing environment for https://github.com/pre-commit/pre-commit-hooks.
+[INFO][m Once installed this environment will be reused.
+[INFO][m This may take a few minutes...
+[INFO][m Installing environment for https://github.com/psf/black.
+[INFO][m Once installed this environment will be reused.
+[INFO][m This may take a few minutes...
+[INFO][m Installing environment for https://github.com/pre-commit/mirrors-mypy.
+[INFO][m Once installed this environment will be reused.
+[INFO][m This may take a few minutes...
+[INFO][m Installing environment for https://github.com/pycqa/flake8.
+[INFO][m Once installed this environment will be reused.
+[INFO][m This may take a few minutes...
+[INFO][m Installing environment for https://github.com/pycqa/doc8.
+[INFO][m Once installed this environment will be reused.
+[INFO][m This may take a few minutes...
+[INFO][m Installing environment for https://github.com/adrienverge/yamllint.git.
+[INFO][m Once installed this environment will be reused.
+[INFO][m This may take a few minutes...
+[INFO][m Installing environment for https://github.com/charliermarsh/ruff-pre-commit.
+[INFO][m Once installed this environment will be reused.
+[INFO][m This may take a few minutes...
+[INFO][m Installing environment for https://github.com/codespell-project/codespell.
+[INFO][m Once installed this environment will be reused.
+[INFO][m This may take a few minutes...
+don't commit to branch...................................................[42mPassed[m
+fix end of files.........................................................[42mPassed[m
+trim trailing whitespace.................................................[42mPassed[m
+black................................................(no files to check)[46;30mSkipped[m
+mypy.................................................(no files to check)[46;30mSkipped[m
+flake8...............................................(no files to check)[46;30mSkipped[m
+doc8.................................................(no files to check)[46;30mSkipped[m
+yamllint.............................................(no files to check)[46;30mSkipped[m
+ruff.................................................(no files to check)[46;30mSkipped[m
+codespell................................................................[42mPassed[m


### PR DESCRIPTION
This PR fixes the pre-commit workflow by replacing the invalid `--files-to-exclude` argument with a proper approach to exclude specific files.

The issue was that pre-commit doesn't support a `--files-to-exclude` option. Instead, this PR uses the `find` command to generate a list of files excluding the problematic file, and then passes those files to pre-commit using the `--files` option.

This approach maintains the original intent of excluding the phantom file while using valid pre-commit CLI syntax.