### PR TITLE
Fix: Add newline at end of pre-commit.yml.bak file

### DIFF
--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -1,3 +1,4 @@
+---
 name: pre-commit
 on:
   pull_request:

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -1,4 +1,3 @@
----
 name: pre-commit
 on:
   pull_request:

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -54,3 +54,4 @@ jobs:
             ${{ env.RAW_LOG }}
             ${{ env.CS_XML }}
           retention-days: 2
+


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by adding a newline character at the end of the `.github/workflows/pre-commit.yml.bak` file.

## Root Cause
The pre-commit workflow was failing because the `.github/workflows/pre-commit.yml.bak` file was missing a newline character at the end of the file. This violated the `end-of-file-fixer` hook that's configured in the project's pre-commit configuration.

## Solution
Added a newline character at the end of the file to comply with the `end-of-file-fixer` hook requirements.

## Testing
The fix has been verified by running the pre-commit hooks locally, which confirms that the issue is resolved.