### PR TITLE
Fix pre-commit workflow to use correct syntax for running on all files

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,8 +30,8 @@ jobs:
           # Clean pre-commit cache to remove phantom files
           pre-commit clean
           pre-commit gc
-          # Run pre-commit on all files except the phantom file
-          find . -type f -not -path "./test/core/helpers/mock_test.py" | xargs pre-commit run --show-diff-on-failure --color=always --files | tee ${RAW_LOG}
+          # Run pre-commit on all files
+          pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5
         if: ${{ failure() }}

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -30,8 +30,8 @@ jobs:
           # Clean pre-commit cache to remove phantom files
           pre-commit clean
           pre-commit gc
-          # Run pre-commit on all files, excluding the phantom file
-          pre-commit run --show-diff-on-failure --color=always --all-files --files test/core/helpers/mock_test.py --exclude | tee ${RAW_LOG}
+          # Run pre-commit on all files except the phantom file
+          find . -type f -not -path "./test/core/helpers/mock_test.py" | xargs pre-commit run --show-diff-on-failure --color=always --files | tee ${RAW_LOG}
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5
         if: ${{ failure() }}

--- a/0001-Fix-Add-missing-newline-at-end-of-pre-commit.yml.bak.patch
+++ b/0001-Fix-Add-missing-newline-at-end-of-pre-commit.yml.bak.patch
@@ -18,6 +18,5 @@ index 73d665839..951ea3f65 100644
 -          retention-days: 2
 \ No newline at end of file
 +          retention-days: 2
--- 
+--
 2.47.1
-


### PR DESCRIPTION
This PR fixes the pre-commit workflow failures by using the correct syntax for running pre-commit on all files.

The root cause of the issue was an incorrect approach to excluding a non-existent file (`test/core/helpers/mock_test.py`) from pre-commit checks. The previous implementation used a find command to filter files before passing them to pre-commit, and the attempted fix in the backup file used pre-commit's built-in exclude option incorrectly.

Since the file doesn't actually exist, there's no need for the exclusion logic at all. This PR simplifies the workflow by using the standard `--all-files` flag without any exclusion, which is the correct approach for running pre-commit on all files in the repository.