### PR TITLE
Fix YAML comment spacing in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
             # properly.
             jinja2,
             pathspec,
-            pytest, # and by extension... pluggy
+            pytest,  # and by extension... pluggy
             click,
             platformdirs
           ]


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by adding proper spacing before a comment in the `.pre-commit-config.yaml` file.

The issue was on line 59 where there was only one space between the code and comment:
```yaml
pytest, # and by extension... pluggy
```

According to yamllint rules, there should be at least 2 spaces before a comment. This PR adds the required spacing:
```yaml
pytest,  # and by extension... pluggy
```

This change ensures the yamllint pre-commit hook passes successfully.