### PR TITLE
Fix YAML comment spacing in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
             # properly.
             jinja2,
             pathspec,
-            pytest,  # and by extension... pluggy
+            pytest, # and by extension... pluggy
             click,
             platformdirs
           ]

--- a/.pre-commit-config.yaml.bak
+++ b/.pre-commit-config.yaml.bak
@@ -57,7 +57,7 @@ repos:
             # properly.
             jinja2,
             pathspec,
-            pytest, # and by extension... pluggy
+            pytest,  # and by extension... pluggy
             click,
             platformdirs
           ]


### PR DESCRIPTION
This PR fixes the YAML comment spacing issue in the `.pre-commit-config.yaml` file. The previous fix was incorrectly applied to the `.pre-commit-config.yaml.bak` file instead of the actual configuration file.

The specific issue was in the mypy section where there were two spaces between the comma and the comment in `pytest,  # and by extension... pluggy`. According to YAML formatting standards, there should be exactly one space after the comma and before the comment.

This fix ensures that the pre-commit workflow passes by applying the correct comment spacing.