### PR TITLE
Fix YAML linting error: add proper spacing before comment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
             # properly.
             jinja2,
             pathspec,
-            pytest, # and by extension... pluggy
+            pytest,  # and by extension... pluggy
             click,
             platformdirs
           ]

--- a/.pre-commit-config.yaml.bak
+++ b/.pre-commit-config.yaml.bak
@@ -57,7 +57,7 @@ repos:
             # properly.
             jinja2,
             pathspec,
-            pytest,  # and by extension... pluggy
+            pytest, # and by extension... pluggy
             click,
             platformdirs
           ]


### PR DESCRIPTION
This PR fixes the YAML linting error in the `.pre-commit-config.yaml` file.

## Issue
The GitHub Actions workflow failed due to a YAML linting error on line 60:
```yaml
pytest, # and by extension... pluggy
```

The error message was: `60:21 [comments] too few spaces before comment`

## Fix
Added an additional space before the comment to comply with yamllint rules:
```yaml
pytest,  # and by extension... pluggy
```

This ensures there are at least 2 spaces before the comment, which is the default requirement in yamllint.