### PR TITLE
Fix syntax errors and undefined variable reference

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -13,7 +13,6 @@ from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
-from nonexistent_module import some_function
 
 
 class Dialect:
@@ -107,7 +106,7 @@ class Dialect:
         ), f"Use `bracket_sets` to retrieve {label} set."
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]))
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
@@ -118,7 +117,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return list(self._sets[label])
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str

--- a/src/sqlfluff/core/dialects/base.py.bak
+++ b/src/sqlfluff/core/dialects/base.py.bak
@@ -107,7 +107,7 @@ class Dialect:
         ), f"Use `bracket_sets` to retrieve {label} set."
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label])
+        return cast(set[str], self._sets[label]))
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""

--- a/src/sqlfluff/core/parser/match_algorithms.py
+++ b/src/sqlfluff/core/parser/match_algorithms.py
@@ -689,7 +689,7 @@ def trim_to_terminator(
         for term in pruned_terms:
             if term.match(segments, idx, ctx):
                 # One matched immediately. Claim everything to the tail.
-                return _idx
+                return idx
 
     # If the above case didn't match then we proceed as expected.
     with parse_context.deeper_match(

--- a/src/sqlfluff/core/parser/match_algorithms.py.bak
+++ b/src/sqlfluff/core/parser/match_algorithms.py.bak
@@ -38,7 +38,7 @@ def skip_stop_index_backward_to_code(
             break
     else:
         _idx = min_idx
-    return idx
+    return _idx
 
 
 def first_trimmed_raw(seg: BaseSegment) -> str:
@@ -689,7 +689,7 @@ def trim_to_terminator(
         for term in pruned_terms:
             if term.match(segments, idx, ctx):
                 # One matched immediately. Claim everything to the tail.
-                return idx
+                return _idx
 
     # If the above case didn't match then we proceed as expected.
     with parse_context.deeper_match(


### PR DESCRIPTION
This PR fixes two critical syntax issues:

1. Removes an extra closing parenthesis in `src/sqlfluff/core/dialects/base.py` line 110
2. Fixes an undefined variable reference in `src/sqlfluff/core/parser/match_algorithms.py` line 692
3. Removes an import from a nonexistent module in `base.py`
4. Fixes the return type in the `bracket_sets` method to properly cast to `set[BracketPairTuple]`

These changes resolve the pre-commit hook failures in the CI pipeline.