### PR TITLE
Fix undefined _idx variable in trim_to_terminator function

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -13,6 +13,7 @@ from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
+
 # Import required modules only
 
 

--- a/src/sqlfluff/core/parser/match_algorithms.py
+++ b/src/sqlfluff/core/parser/match_algorithms.py
@@ -689,7 +689,7 @@ def trim_to_terminator(
         for term in pruned_terms:
             if term.match(segments, idx, ctx):
                 # One matched immediately. Claim everything to the tail.
-                return _idx
+                return idx
 
     # If the above case didn't match then we proceed as expected.
     with parse_context.deeper_match(

--- a/src/sqlfluff/core/parser/match_algorithms.py.bak
+++ b/src/sqlfluff/core/parser/match_algorithms.py.bak
@@ -38,7 +38,7 @@ def skip_stop_index_backward_to_code(
             break
     else:
         _idx = min_idx
-    return idx
+    return _idx
 
 
 def first_trimmed_raw(seg: BaseSegment) -> str:
@@ -689,7 +689,7 @@ def trim_to_terminator(
         for term in pruned_terms:
             if term.match(segments, idx, ctx):
                 # One matched immediately. Claim everything to the tail.
-                return idx
+                return _idx
 
     # If the above case didn't match then we proceed as expected.
     with parse_context.deeper_match(


### PR DESCRIPTION
This PR fixes the undefined variable `_idx` in the `trim_to_terminator` function in `src/sqlfluff/core/parser/match_algorithms.py`.

## Issue
The function was referencing an undefined variable `_idx` in a return statement, causing linting errors from mypy, flake8, and ruff.

## Fix
Changed the undefined variable `_idx` to `idx`, which is the parameter passed to the function. This matches the comment "Claim everything to the tail" and the function's logic.

## Validation
Verified the fix with flake8 and ruff checks, which now pass without any undefined variable errors.