### PR TITLE
Fix pre-commit CI workflow by excluding log files from checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Ignore CI logs
+pre-commit.log
+pre-commit.xml
+
 # Ignore IDE files
 .vscode
 .idea

--- a/.gitignore.bak
+++ b/.gitignore.bak
@@ -1,0 +1,65 @@
+# Ignore IDE files
+.vscode
+.idea
+/.sqlfluff
+**/.DS_Store
+
+# Ignore Python cache and prebuilt things
+.cache
+__pycache__
+*.egg-info
+*.pyc
+build
+_build
+dist
+.pytest_cache
+/sqlfluff-*
+
+# Ignore the Environment
+env
+.tox
+venv
+.venv
+.python-version
+uv.lock
+
+# Ignore coverage reports
+.coverage
+.coverage.*
+coverage.xml
+htmlcov
+
+# Ignore test reports
+.test-reports
+test-reports
+
+# Ignore root testing sql & python files
+/test*.sql
+/test*.py
+/test*.txt
+/.hypothesis/
+
+# Ignore dbt outputs from testing
+/target
+
+# Ignore any timing outputs
+/*.csv
+
+# Ignore conda environment.yml contributors might be using and direnv config
+environment.yml
+.envrc
+**/*FIXED.sql
+*.prof
+# Ignore temp packages.yml generated during testing.
+plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/packages.yml
+
+# VSCode
+.vscode
+*.code-workspace
+
+# Emacs
+*~
+
+# Mypyc outputs
+*.pyd
+*.so

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: '^(pre-commit\.log|pre-commit\.xml)$'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -18,7 +19,9 @@ repos:
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/(dbt_utils_0.8.0/)?last_day.sql|
             test/fixtures/linter/indentation_errors.sql|
             test/fixtures/templater/jinja_d_roundtrip/test.sql|
-            fix-eof-newline\.patch.*
+            fix-eof-newline\.patch.*|
+            pre-commit\.log|
+            pre-commit\.xml
           )$
       - id: trailing-whitespace
         exclude: |
@@ -30,7 +33,9 @@ repos:
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/macro_in_macro.sql|
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/last_day.sql|
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/dbt_utils_0.8.0/last_day.sql|
-            test/fixtures/linter/sqlfluffignore/
+            test/fixtures/linter/sqlfluffignore/|
+            pre-commit\.log|
+            pre-commit\.xml
           )$
   - repo: https://github.com/psf/black
     rev: 25.1.0
@@ -93,5 +98,5 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-        exclude: (?x)^(test/fixtures/.*|pyproject.toml)$
+        exclude: (?x)^(test/fixtures/.*|pyproject.toml|pre-commit\.log|pre-commit\.xml)$
         additional_dependencies: [tomli]

--- a/.pre-commit-config.yaml.bak
+++ b/.pre-commit-config.yaml.bak
@@ -1,3 +1,4 @@
+exclude: '^(pre-commit\.log|pre-commit\.xml)$'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -18,7 +19,9 @@ repos:
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/(dbt_utils_0.8.0/)?last_day.sql|
             test/fixtures/linter/indentation_errors.sql|
             test/fixtures/templater/jinja_d_roundtrip/test.sql|
-            fix-eof-newline\.patch.*
+            fix-eof-newline\.patch.*|
+            pre-commit\.log|
+            pre-commit\.xml
           )$
       - id: trailing-whitespace
         exclude: |
@@ -30,7 +33,9 @@ repos:
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/macro_in_macro.sql|
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/last_day.sql|
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/dbt_utils_0.8.0/last_day.sql|
-            test/fixtures/linter/sqlfluffignore/
+            test/fixtures/linter/sqlfluffignore/|
+            pre-commit\.log|
+            pre-commit\.xml
           )$
   - repo: https://github.com/psf/black
     rev: 25.1.0


### PR DESCRIPTION
This PR fixes the pre-commit CI workflow failure by excluding the log files generated during the workflow from being checked by pre-commit hooks.

## Root Cause
The pre-commit workflow was failing because it was generating log files (`pre-commit.log` and `pre-commit.xml`) during execution, and then these files were being checked by the pre-commit hooks themselves. This created a circular issue where the workflow would always fail because the generated files didn't meet the formatting requirements.

## Changes Made
1. Added a global exclude pattern for `pre-commit.log` and `pre-commit.xml` files
2. Updated specific hook exclude patterns to include these log files
3. Added the log files to `.gitignore` to prevent them from being committed

These changes ensure that the log files generated during CI execution won't cause the pre-commit hooks to fail.