### PR TITLE
Fix undefined variable reference in trim_to_terminator function

### DIFF
--- a/src/sqlfluff/core/parser/match_algorithms.py
+++ b/src/sqlfluff/core/parser/match_algorithms.py
@@ -689,7 +689,7 @@ def trim_to_terminator(
         for term in pruned_terms:
             if term.match(segments, idx, ctx):
                 # One matched immediately. Claim everything to the tail.
-                return _idx
+                return idx
 
     # If the above case didn't match then we proceed as expected.
     with parse_context.deeper_match(

--- a/src/sqlfluff/core/parser/match_algorithms.py.bak
+++ b/src/sqlfluff/core/parser/match_algorithms.py.bak
@@ -38,7 +38,7 @@ def skip_stop_index_backward_to_code(
             break
     else:
         _idx = min_idx
-    return idx
+    return _idx
 
 
 def first_trimmed_raw(seg: BaseSegment) -> str:
@@ -689,7 +689,7 @@ def trim_to_terminator(
         for term in pruned_terms:
             if term.match(segments, idx, ctx):
                 # One matched immediately. Claim everything to the tail.
-                return idx
+                return _idx
 
     # If the above case didn't match then we proceed as expected.
     with parse_context.deeper_match(


### PR DESCRIPTION
This PR fixes the undefined variable reference in the `trim_to_terminator` function in `src/sqlfluff/core/parser/match_algorithms.py`.

## Issue
The function was trying to return a variable named `_idx` that doesn't exist in that scope. This was causing the pre-commit hooks to fail with the following errors:
- mypy error: Name "_idx" is not defined [name-defined]
- flake8 error: F821 undefined name '_idx'
- ruff error: F821 Undefined name `_idx`

## Fix
Changed line 692 from:
```python
return _idx
```

To:
```python
return idx
```

This uses the function parameter `idx` which is in scope, rather than the undefined `_idx` variable.

## Validation
All pre-commit hooks now pass successfully on the modified file.