### PR TITLE
Fix pre-commit workflow by writing logs to /tmp directory

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,8 +6,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     env:
-      RAW_LOG: pre-commit.log
-      CS_XML: pre-commit.xml
+      RAW_LOG: /tmp/pre-commit.log
+      CS_XML: /tmp/pre-commit.xml
       SKIP: no-commit-to-branch
     steps:
       - run: sudo apt-get update && sudo apt-get install cppcheck


### PR DESCRIPTION
This PR fixes the pre-commit workflow failures by writing the log files to the /tmp directory instead of the repository root.

The root cause of the issue was that the pre-commit hooks were modifying the log file (pre-commit.log) that was being written to during the pre-commit run itself, creating a recursive modification problem.

By writing the logs to a location outside the repository directory (/tmp), we prevent the pre-commit hooks from seeing and modifying the log files, thus breaking the recursive loop.