### PR TITLE
Fix pre-commit workflow to prevent circular log file issue

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,8 +30,10 @@ jobs:
           # Clean pre-commit cache to remove phantom files
           pre-commit clean
           pre-commit gc
-          # Run pre-commit on all files
-          pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
+          # Run pre-commit on all files and output to a temporary location
+          mkdir -p /tmp/pre-commit-logs
+          pre-commit run --show-diff-on-failure --color=always --all-files | tee /tmp/pre-commit-logs/pre-commit.log
+          cp /tmp/pre-commit-logs/pre-commit.log ${RAW_LOG}
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5
         if: ${{ failure() }}

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -30,8 +30,8 @@ jobs:
           # Clean pre-commit cache to remove phantom files
           pre-commit clean
           pre-commit gc
-          # Run pre-commit on all files except the phantom file
-          find . -type f -not -path "./test/core/helpers/mock_test.py" | xargs pre-commit run --show-diff-on-failure --color=always --files | tee ${RAW_LOG}
+          # Run pre-commit on all files
+          pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5
         if: ${{ failure() }}


### PR DESCRIPTION
This PR fixes the pre-commit workflow issue where pre-commit hooks were modifying the pre-commit.log file itself during the CI run, creating a circular issue.

**Root Cause:**
When pre-commit runs with the --show-diff-on-failure flag and outputs to pre-commit.log via the tee command, it creates a file that is then processed by subsequent pre-commit hooks. This happens because the pre-commit.log file doesn't exist when pre-commit starts running, but is created during the run.

**Solution:**
The solution redirects the pre-commit output to a temporary directory outside the repository, then copies the log back after pre-commit has finished running. This prevents pre-commit hooks from processing the log file itself.