### PR TITLE
Fix: Remove duplicate exclude key in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
 exclude: '\.bak$'  # Global exclude for all hooks
-exclude: '\.bak$'  # Global exclude for all hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
This PR fixes the GitHub Actions workflow failure by removing the duplicate `exclude` key in the `.pre-commit-config.yaml` file.

### Issue
The workflow was failing due to a YAML syntax error caused by duplicate `exclude` keys at the top level of the `.pre-commit-config.yaml` file:

```yaml
exclude: '\.bak$'  # Global exclude for all hooks
exclude: '\.bak$'  # Global exclude for all hooks
```

This violates the YAML specification, which does not allow duplicate keys in mappings.

### Fix
Removed one of the duplicate `exclude` lines, keeping only one global exclude pattern.

### Validation
Verified the fix by running `pre-commit run yamllint --all-files` locally, which passed successfully.