### PR TITLE
Fix circular dependency issue with pre-commit.log

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,8 +6,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     env:
-      RAW_LOG: pre-commit.log
-      CS_XML: pre-commit.xml
+      RAW_LOG: /tmp/pre-commit.log
+      CS_XML: /tmp/pre-commit.xml
       SKIP: no-commit-to-branch
     steps:
       - run: sudo apt-get update && sudo apt-get install cppcheck

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -30,8 +30,8 @@ jobs:
           # Clean pre-commit cache to remove phantom files
           pre-commit clean
           pre-commit gc
-          # Run pre-commit on all files except the phantom file
-          find . -type f -not -path "./test/core/helpers/mock_test.py" | xargs pre-commit run --show-diff-on-failure --color=always --files | tee ${RAW_LOG}
+          # Run pre-commit on all files
+          pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5
         if: ${{ failure() }}

--- a/pre-commit.log
+++ b/pre-commit.log
@@ -1,1 +1,0 @@
-This is a test log file


### PR DESCRIPTION
This PR fixes the circular dependency issue with pre-commit.log by:

1. Untracking pre-commit.log from git repository
2. Modifying the workflow to use temporary files in /tmp directory for logs

The issue was that pre-commit.log was both:
- A tracked file in the repository that is subject to pre-commit hooks
- The output destination for the pre-commit hook results via the `tee ${RAW_LOG}` command

This created a circular dependency where pre-commit would modify the log file during its run, causing the hooks to report failures.

The solution ensures that the log files are stored in a temporary location that is not tracked by git or checked by pre-commit hooks.