### PR TITLE
Fix: Add missing newline at end of .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,3 +95,4 @@ repos:
       - id: codespell
         exclude: (?x)^(test/fixtures/.*|pyproject.toml)$
         additional_dependencies: [tomli]
+# End of file


### PR DESCRIPTION
This PR fixes the issue with the pre-commit workflow failing due to a missing newline at the end of the `.pre-commit-config.yaml` file.

The fix adds a comment at the end of the file with a proper newline character, which satisfies the `end-of-file-fixer` pre-commit hook.

This should resolve the CI failure in the workflow run.