### PR TITLE
Fix: Remove extra blank line at end of base.py.bak file

### DIFF
--- a/src/sqlfluff/core/dialects/base.py.bak
+++ b/src/sqlfluff/core/dialects/base.py.bak
@@ -394,4 +394,3 @@ class Dialect:
     def get_root_segment(self) -> Union[type[BaseSegment], Matchable]:
         """Get the root segment of the dialect."""
         return self.ref(self.root_segment_name)
-


### PR DESCRIPTION
This PR fixes the pre-commit hook failure by removing the extra blank line at the end of `src/sqlfluff/core/dialects/base.py.bak` file.

The pre-commit hook `end-of-file-fixer` was failing because the file had an extra blank line at the end, which violates the project's code style requirements. This PR removes that extra blank line to ensure the file complies with the project's standards.

Fixes the CI failure in workflow run: https://github.com/CloudSmith-Agent-Benchmark/sqlfluff/actions/runs/15506073142