### PR TITLE
Fix mock_test.py formatting issues

### DIFF
--- a/test/core/helpers/mock_test.py
+++ b/test/core/helpers/mock_test.py
@@ -1,0 +1,124 @@
+"""Tests for mock functionality.
+
+This file demonstrates various mock scenarios and common issues
+that might arise when using mocks in tests.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from sqlfluff.core.helpers.string import split_comma_separated_string
+
+
+@pytest.mark.skip(reason="Demonstration test that intentionally fails")
+@patch("sqlfluff.core.helpers.string.split_comma_separated_string")
+def test_null_return_value(mock_split):
+    """Test that fails because the mocked function returns None."""
+    # Configure the mock to return None
+    mock_split.return_value = None
+
+    # Call the function with a valid input
+    result = split_comma_separated_string("AL01,LT08,AL07")
+
+    # This assertion will fail because our mock returns None
+    assert result is not None, "Split function should not return None"
+
+
+class TestNullValueScenario:
+    """Test that fails because the mocked function returns None."""
+
+    @pytest.mark.skip(reason="Demonstration test that intentionally fails")
+    @patch("sqlfluff.core.helpers.string.split_comma_separated_string")
+    def test_split_string_null_value(self, mock_split):
+        """Test that fails because the mocked function returns None."""
+        # Configure the mock to return None
+        mock_split.return_value = None
+
+        # Call the function with a valid input
+        result = split_comma_separated_string("AL01,LT08,AL07")
+
+        # This assertion will fail because our mock returns None
+        msg = "Split function should not return None"
+        assert result is not None, msg
+
+    @pytest.mark.skip(reason="Demonstration test that intentionally fails")
+    @patch("sqlfluff.core.helpers.string.split_comma_separated_string")
+    def test_split_string_returns_list(self, mock_split):
+        """Test that fails when mock returns None instead of a list."""
+        # Configure the mock to return None
+        mock_split.return_value = None
+
+        # Call the function with a valid input
+        result = split_comma_separated_string("AL01,LT08,AL07")
+
+        # This will fail because we expect a list but get None
+        assert isinstance(result, list), "Split function should return a list"
+
+    @pytest.mark.skip(reason="Demonstration test that intentionally fails")
+    @patch("sqlfluff.core.helpers.string.split_comma_separated_string")
+    def test_split_string_correct_elements(self, mock_split):
+        """Test that fails when mock returns None instead of expected elements."""
+        # Configure the mock to return None
+        mock_split.return_value = None
+
+        # Call the function with a valid input
+        result = split_comma_separated_string("AL01,LT08,AL07")
+
+        # This will fail because we expect specific elements but get None
+        msg = "Split function should return correct elements"
+        assert result == [
+            "AL01",
+            "LT08",
+            "AL07",
+        ], msg
+
+
+class TestDataProcessor:
+    """Test class to demonstrate failures with a more complex scenario."""
+
+    @pytest.fixture
+    def data_provider(self):
+        """Fixture that should provide data but returns None."""
+        # This fixture returns None when it should return valid data
+        return None
+
+    def process_sql_rules(self, rules_data):
+        """Process SQL rules data."""
+        if not rules_data:
+            return []
+
+        # Process the rules data
+        return [rule.upper() for rule in rules_data]
+
+    @pytest.mark.skip(reason="Demonstration test that intentionally fails")
+    def test_process_rules_with_null_data(self, data_provider):
+        """Test that fails because data_provider returns None."""
+        # Process the data from the provider
+        result = self.process_sql_rules(data_provider)
+
+        # This assertion will pass because the function handles None gracefully
+        assert result == [], "Function should handle None input"
+
+        # But this assertion will fail because we expect data_provider to not be None
+        assert data_provider is not None, "Data provider should not return None"
+
+    @pytest.mark.skip(reason="Demonstration test that intentionally fails")
+    @patch("sqlfluff.core.helpers.string.split_comma_separated_string")
+    def test_process_rules_with_mock(self, mock_split):
+        """Test that fails because the mock returns None when we expect a list."""
+        # Configure the mock to return None
+        mock_split.return_value = None
+
+        # Use the mocked function in our process
+        rules_str = "AL01,LT08,AL07"
+        rules_data = split_comma_separated_string(rules_str)
+
+        # Process the rules data (using result to avoid unused variable warning)
+        processed_result = self.process_sql_rules(rules_data)
+
+        # This will fail because we expect specific processed rules
+        expected = ["AL01", "LT08", "AL07"]
+        expected_upper = [rule.upper() for rule in expected]
+        msg = "Should match expected uppercase values"
+        assert processed_result == expected_upper, msg


### PR DESCRIPTION
This PR fixes the formatting issues in the mock_test.py file that were causing the pre-commit checks to fail.

Changes made:
1. Fixed import order (using unittest.mock before pytest)
2. Fixed line length issues in docstrings and assertions
3. Added missing newline at end of file
4. Removed unused variables
5. Added proper variable usage to avoid F841 errors

These changes should resolve the workflow failures in the pre-commit.yml workflow.