### PR TITLE
Fix import order in mock_test.py

### DIFF
--- a/test/core/helpers/mock_test.py
+++ b/test/core/helpers/mock_test.py
@@ -3,8 +3,9 @@
 This module demonstrates common issues with mocking.
 """
 
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from sqlfluff.core.helpers.string import split_comma_separated_string
 


### PR DESCRIPTION
This PR fixes the import ordering issue in `test/core/helpers/mock_test.py` that was causing the pre-commit workflow to fail.

Changes made:
1. Reordered imports to follow the proper convention:
   - Standard library imports first (`unittest.mock`)
   - Third-party imports second (`pytest`)
   - First-party imports last (`sqlfluff.core.helpers.string`)
2. Added proper spacing between import groups
3. Ensured the file has a proper newline at the end

This fixes the ruff linter error I001: "Import block is un-sorted or un-formatted" and ensures the end-of-file-fixer hook passes.