### PR TITLE
Fix import order in mock_test.py to comply with ruff linting rules

### DIFF
--- a/test/core/helpers/mock_test.py
+++ b/test/core/helpers/mock_test.py
@@ -3,8 +3,9 @@
 This module demonstrates common issues with mocking.
 """
 
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from sqlfluff.core.helpers.string import split_comma_separated_string
 


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by properly sorting the import statements in `test/core/helpers/mock_test.py` according to the project's import order convention.

## Changes:
- Reordered the import statements to follow the proper convention:
  - Standard library imports first (`from unittest.mock import patch`)
  - Third-party imports second (`import pytest`)
  - First-party imports last (`from sqlfluff.core.helpers.string import split_comma_separated_string`)
- Added proper spacing between import groups
- Ensured the file has a proper newline at the end

This addresses the ruff linter error I001: "Import block is un-sorted or un-formatted" that was causing the workflow to fail.