### PR TITLE
Add .bak files to trailing-whitespace exclusion pattern

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,8 @@ repos:
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/macro_in_macro.sql|
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/last_day.sql|
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/dbt_utils_0.8.0/last_day.sql|
-            test/fixtures/linter/sqlfluffignore/
+            test/fixtures/linter/sqlfluffignore/|
+            .*\.bak
           )$
   - repo: https://github.com/psf/black
     rev: 25.1.0

--- a/.pre-commit-config.yaml.bak
+++ b/.pre-commit-config.yaml.bak
@@ -17,7 +17,8 @@ repos:
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/macro_in_macro.sql|
             plugins/sqlfluff-templater-dbt/test/fixtures/dbt.*/templated_output/(dbt_utils_0.8.0/)?last_day.sql|
             test/fixtures/linter/indentation_errors.sql|
-            test/fixtures/templater/jinja_d_roundtrip/test.sql
+            test/fixtures/templater/jinja_d_roundtrip/test.sql|
+            .*\.bak
           )$
       - id: trailing-whitespace
         exclude: |


### PR DESCRIPTION
This PR adds the `.*\.bak` exclusion pattern to the trailing-whitespace pre-commit hook, matching the existing exclusion pattern in the end-of-file-fixer hook. This will prevent the pre-commit hook from failing on backup files that may contain trailing whitespace.