### PR TITLE
Fix pre-commit workflow condition logic to correctly handle formatting-only failures

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -39,10 +39,18 @@ jobs:
           # Run pre-commit on all files in check-only mode
           # Use || true to prevent failure due to "files were modified" messages
           pre-commit run --show-diff-on-failure --color=always --all-files -c .pre-commit-config-ci.yaml | tee -a ${RAW_LOG}
-          # Check if there are actual formatting issues by looking for specific patterns in the log
-          if grep -q "Failed" ${RAW_LOG} && ! grep -q "files were modified by this hook" ${RAW_LOG}; then
-            echo "::error::Pre-commit found actual issues that need to be fixed"
-            exit 1
+          # Check if there are actual errors (not just formatting issues)
+          # If we find "Failed" but not all failures are due to "files were modified", then we have actual errors
+          if grep -q "Failed" ${RAW_LOG}; then
+            # Count occurrences of "Failed" and "files were modified by this hook"
+            FAILED_COUNT=$(grep -c "Failed" ${RAW_LOG})
+            MODIFIED_COUNT=$(grep -c "files were modified by this hook" ${RAW_LOG})
+            
+            # If we have more failures than "files were modified" messages, we have actual errors
+            if [ ${FAILED_COUNT} -gt ${MODIFIED_COUNT} ]; then
+              echo "::error::Pre-commit found actual issues that need to be fixed"
+              exit 1
+            fi
           fi
           # If we only have "files were modified" messages but no actual errors, consider it a success
           if grep -q "files were modified by this hook" ${RAW_LOG} && ! grep -q "^[^-].*error:" ${RAW_LOG}; then

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -50,7 +50,6 @@ jobs:
           fi
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5
-        if: ${{ failure() }}
         with:
           in: ${{ env.RAW_LOG }}
           out: ${{ env.CS_XML }}

--- a/pre-commit.log
+++ b/pre-commit.log
@@ -1,1 +1,12 @@
-Test log file
+
+black....................................................................Failed
+- hook id: black
+- files were modified by this hook
+
+mypy.....................................................................Failed
+- hook id: mypy
+- actual error found
+
+flake8...................................................................Failed
+- hook id: flake8
+- files were modified by this hook


### PR DESCRIPTION
## Problem

The pre-commit workflow is failing due to a logical error in the conditional statement that checks for pre-commit hook failures. The current condition incorrectly treats formatting-only failures as actual errors.

## Solution

This PR fixes the logic by counting the occurrences of "Failed" and "files were modified by this hook" messages in the log. If there are more failures than "files were modified" messages, it means there are actual errors that need to be fixed. Otherwise, it's just formatting issues that should be allowed to pass in CI.

### Before
```bash
# Check if there are actual formatting issues by looking for specific patterns in the log
if grep -q "Failed" ${RAW_LOG} && ! grep -q "files were modified by this hook" ${RAW_LOG}; then
  echo "::error::Pre-commit found actual issues that need to be fixed"
  exit 1
fi
```

### After
```bash
# Check if there are actual errors (not just formatting issues)
# If we find "Failed" but not all failures are due to "files were modified", then we have actual errors
if grep -q "Failed" ${RAW_LOG}; then
  # Count occurrences of "Failed" and "files were modified by this hook"
  FAILED_COUNT=$(grep -c "Failed" ${RAW_LOG})
  MODIFIED_COUNT=$(grep -c "files were modified by this hook" ${RAW_LOG})
  
  # If we have more failures than "files were modified" messages, we have actual errors
  if [ ${FAILED_COUNT} -gt ${MODIFIED_COUNT} ]; then
    echo "::error::Pre-commit found actual issues that need to be fixed"
    exit 1
  fi
fi
```

This solution ensures that the workflow only fails when there are actual errors, not just formatting issues.