### PR TITLE
Fix pre-commit workflow by removing unrecognized --no-autofix flag

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -33,7 +33,7 @@ jobs:
           # Create empty log file with newline to prevent end-of-file-fixer issues
           echo "" > ${RAW_LOG}
           # Run pre-commit on all files in check-only mode
-          pre-commit run --hook-stage manual --show-diff-on-failure --color=always --all-files --no-autofix -c .pre-commit-config-ci.yaml | tee -a ${RAW_LOG}
+          pre-commit run --hook-stage manual --show-diff-on-failure --color=always --all-files -c .pre-commit-config-ci.yaml | tee -a ${RAW_LOG}
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5
         if: ${{ failure() }}

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -33,7 +33,7 @@ jobs:
           # Create empty log file with newline to prevent end-of-file-fixer issues
           echo "" > ${RAW_LOG}
           # Run pre-commit on all files in check-only mode
-          pre-commit run --hook-stage manual --show-diff-on-failure --color=always --all-files -c .pre-commit-config-ci.yaml | tee -a ${RAW_LOG}
+          pre-commit run --hook-stage manual --show-diff-on-failure --color=always --all-files --no-autofix -c .pre-commit-config-ci.yaml | tee -a ${RAW_LOG}
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5
         if: ${{ failure() }}


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by removing the unrecognized `--no-autofix` flag from the pre-commit command.

## Root Cause
The workflow was failing because the pre-commit command was using the `--no-autofix` flag, which is not a recognized argument in the current version of pre-commit being used. The error message clearly stated: `pre-commit: error: unrecognized arguments: --no-autofix`.

## Solution
Removed the `--no-autofix` flag from the pre-commit command in the workflow file. The CI-specific pre-commit configuration (`.pre-commit-config-ci.yaml`) already ensures hooks run in check-only mode by setting appropriate arguments for each hook (e.g., Black with `args: [--check]`).

## Validation
Tested the modified command locally and confirmed it runs successfully without errors.