### PR TITLE
Fix ANSI color code stripping pattern in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -43,7 +43,7 @@ jobs:
             # Check if the failure is due to "files were modified by this hook"
             # Use grep -c to count occurrences and check if any were found
             # Strip ANSI color codes before grepping to ensure reliable pattern matching
-            if [ $(cat ${RAW_LOG} | sed 's/\x1b\[[0-9;]*m//g' | grep -c "files were modified by this hook") -gt 0 ]; then
+            if [ $(cat ${RAW_LOG} | sed -E 's/\x1B(\[[0-9;]*[a-zA-Z]|\[[0-9]m|\(B)//g' | grep -c "files were modified by this hook") -gt 0 ]; then
               echo "Hooks reported files would be modified, but this is expected in check mode. Continuing..."
               exit 0
             fi

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -43,7 +43,7 @@ jobs:
             # Check if the failure is due to "files were modified by this hook"
             # Use grep -c to count occurrences and check if any were found
             # Strip ANSI color codes before grepping to ensure reliable pattern matching
-            if [ $(cat ${RAW_LOG} | sed -E "s/\x1B\[([0-9]{1,3}(;[0-9]{1,3})*)?[mGK]//g" | grep -c "files were modified by this hook") -gt 0 ]; then
+            if [ $(cat ${RAW_LOG} | sed 's/\x1b\[[0-9;]*m//g' | grep -c "files were modified by this hook") -gt 0 ]; then
               echo "Hooks reported files would be modified, but this is expected in check mode. Continuing..."
               exit 0
             fi


### PR DESCRIPTION
This PR fixes the issue with ANSI color code stripping in the pre-commit workflow.

The root cause was an ineffective regex pattern used in the `sed` command that didn't properly strip all ANSI color codes before grepping for "files were modified by this hook". This caused the workflow to fail even when the only issue was that pre-commit hooks would make changes, which is expected in check mode.

The fix uses a more comprehensive regex pattern that handles various ANSI color code formats, ensuring that the grep command can properly detect the "files were modified by this hook" message regardless of color formatting.