### PR TITLE
Fix missing docstring in src/test.py

### DIFF
--- a/src/test.py
+++ b/src/test.py
@@ -1,0 +1,1 @@
+"""Test module for the SQLFluff project."""


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by adding a module-level docstring to the empty `src/test.py` file.

## Issue
The GitHub Actions workflow 'pre-commit' failed because the file `src/test.py` exists but was completely empty. This violated the code style rule enforced by the Ruff linter which requires all public Python modules to have a docstring (rule D100).

## Solution
Added a simple module-level docstring to the file to satisfy the Ruff linter requirements.

## Testing
Verified locally that the ruff pre-commit hook passes with this change.