### PR TITLE
Fix pre-commit workflow to handle 'files were modified' messages correctly

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -51,6 +51,7 @@ jobs:
             # If all failures are just "files were modified" messages, consider it a success
             if [ "${FAILED_COUNT}" -eq "${MODIFIED_COUNT}" ]; then
               echo "::warning::Pre-commit reported 'Failed' but these were just 'files were modified' messages"
+              exit 0  # Explicitly set success exit code
             # If we have actual errors (failures without "files were modified"), exit with error
             elif [ "${MODIFIED_COUNT}" -eq 0 ]; then
               echo "::error::Pre-commit found actual issues that need to be fixed"
@@ -61,6 +62,7 @@ jobs:
               exit 1
             else
               echo "::warning::Pre-commit reported 'files were modified' but no actual errors were found"
+              exit 0  # Explicitly set success exit code
             fi
           fi
       - name: Convert Raw Log to Checkstyle format (launch action)

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -51,6 +51,7 @@ jobs:
             # If all failures are just "files were modified" messages, consider it a success
             if [ "${FAILED_COUNT}" -eq "${MODIFIED_COUNT}" ]; then
               echo "::warning::Pre-commit reported 'Failed' but these were just 'files were modified' messages"
+              exit 0  # Explicitly set success exit code
             # If we have actual errors (failures without "files were modified"), exit with error
             elif [ "${MODIFIED_COUNT}" -eq 0 ]; then
               echo "::error::Pre-commit found actual issues that need to be fixed"

--- a/test.log
+++ b/test.log
@@ -1,0 +1,3 @@
+black....................................................................Failed
+- hook id: black
+- files were modified by this hook

--- a/test_script/test_pre_commit.sh
+++ b/test_script/test_pre_commit.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Create a test log file
+echo "black....................................................................Failed" > test.log
+echo "- hook id: black" >> test.log
+echo "- files were modified by this hook" >> test.log
+
+# Count the number of failures and "files were modified" messages
+FAILED_COUNT=$(grep -c "Failed" test.log || echo 0)
+MODIFIED_COUNT=$(grep -c "files were modified by this hook" test.log || echo 0)
+ERROR_COUNT=$(grep -c "^[^-].*error:" test.log || echo 0)
+
+echo "Found ${FAILED_COUNT} failures, ${MODIFIED_COUNT} 'files were modified' messages, and ${ERROR_COUNT} errors"
+
+# Check if there are any failures in the log
+if [ "${FAILED_COUNT}" -gt 0 ]; then
+  # If all failures are just "files were modified" messages, consider it a success
+  if [ "${FAILED_COUNT}" -eq "${MODIFIED_COUNT}" ]; then
+    echo "::warning::Pre-commit reported 'Failed' but these were just 'files were modified' messages"
+    exit 0  # Explicitly set success exit code
+  # If we have actual errors (failures without "files were modified"), exit with error
+  elif [ "${MODIFIED_COUNT}" -eq 0 ]; then
+    echo "::error::Pre-commit found actual issues that need to be fixed"
+    exit 1
+  # If we have a mix of "files were modified" and other failures, check for actual errors
+  elif [ "${ERROR_COUNT}" -gt 0 ]; then
+    echo "::error::Pre-commit found actual errors that need to be fixed"
+    exit 1
+  else
+    echo "::warning::Pre-commit reported 'files were modified' but no actual errors were found"
+    exit 0  # Explicitly set success exit code
+  fi
+fi
+
+echo "No failures found"


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by explicitly setting a success exit code (0) when all failures are just 'files were modified' messages.

The root cause of the failure was that the workflow script correctly detected that all failures were 'files were modified' messages but didn't explicitly set a success exit code. Since the pre-commit command itself returned a non-zero exit code, this caused the GitHub Actions step to fail.

Changes made:
1. Added `exit 0` after the warning message when all failures are just 'files were modified' messages
2. Added `exit 0` in the other case where no actual errors were found

This ensures the workflow step succeeds when all failures are just modification reports, which appears to be the intended behavior.