### PR TITLE
Fix pre-commit workflow by removing pre-commit.log from Git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/packages.yml
 # Mypyc outputs
 *.pyd
 *.so
+
+# Ignore pre-commit log files
+pre-commit.log
+pre-commit.xml

--- a/.gitignore.bak
+++ b/.gitignore.bak
@@ -1,0 +1,65 @@
+# Ignore IDE files
+.vscode
+.idea
+/.sqlfluff
+**/.DS_Store
+
+# Ignore Python cache and prebuilt things
+.cache
+__pycache__
+*.egg-info
+*.pyc
+build
+_build
+dist
+.pytest_cache
+/sqlfluff-*
+
+# Ignore the Environment
+env
+.tox
+venv
+.venv
+.python-version
+uv.lock
+
+# Ignore coverage reports
+.coverage
+.coverage.*
+coverage.xml
+htmlcov
+
+# Ignore test reports
+.test-reports
+test-reports
+
+# Ignore root testing sql & python files
+/test*.sql
+/test*.py
+/test*.txt
+/.hypothesis/
+
+# Ignore dbt outputs from testing
+/target
+
+# Ignore any timing outputs
+/*.csv
+
+# Ignore conda environment.yml contributors might be using and direnv config
+environment.yml
+.envrc
+**/*FIXED.sql
+*.prof
+# Ignore temp packages.yml generated during testing.
+plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/packages.yml
+
+# VSCode
+.vscode
+*.code-workspace
+
+# Emacs
+*~
+
+# Mypyc outputs
+*.pyd
+*.so

--- a/pre-commit.log
+++ b/pre-commit.log
@@ -1,1 +1,0 @@
-Test log file


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by:

1. Removing pre-commit.log from Git tracking
2. Adding pre-commit.log and pre-commit.xml to .gitignore

The root cause of the workflow failure was that the pre-commit.log file was being tracked in Git with content "Test log file", but the workflow script was trying to create an empty file with just a newline. This conflict caused the pre-commit hooks to report that files were modified, leading to the workflow failure.

By removing the file from Git tracking and adding it to .gitignore, we ensure that:
1. The workflow can freely create and write to the log file
2. Log files are not committed to the repository (following best practices)
3. Future runs of the workflow won't encounter the same issue