### PR TITLE
Fix missing module docstring in src/test.py

### DIFF
--- a/src/test.py
+++ b/src/test.py
@@ -1,0 +1,3 @@
+"""Test module for SQLFluff functionality."""
+
+# This file can be used for testing purposes


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by adding a module-level docstring to `src/test.py`.

## Issue
The pre-commit workflow was failing because `src/test.py` was missing a module-level docstring, which is required by the ruff linter's D100 rule.

## Solution
Added a proper module-level docstring to the file to satisfy the linting requirements.

## Validation
All pre-commit hooks now pass successfully.