### PR TITLE
Fix trailing whitespace issues in pre-commit.yml workflow file

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -54,13 +54,13 @@ jobs:
 
           # Get the current branch name
           BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-          
+
           # Check if we're on a branch specifically fixing whitespace issues
           if [[ "${BRANCH_NAME}" == *"fix-trailing-whitespace"* ]]; then
             echo "::warning::On branch ${BRANCH_NAME} which is fixing whitespace issues - allowing pre-commit failures related to whitespace"
             exit 0  # Always succeed on whitespace-fixing branches
           fi
-          
+
           # Check if there are any failures in the log
           if [ "${FAILED_COUNT}" -gt 0 ]; then
             # If all failures are just "files were modified" messages, consider it a success


### PR DESCRIPTION
This PR fixes the trailing whitespace issues in the pre-commit.yml workflow file that were causing the pre-commit workflow to fail.

Specifically:
1. Removed trailing whitespace from line 57
2. Removed trailing whitespace from line 63

These changes ensure the yamllint pre-commit hook passes without errors.