### PR TITLE
Fix trailing whitespace in pre-commit.yml workflow file

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -54,13 +54,11 @@ jobs:
 
           # Get the current branch name
           BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-          
           # Check if we're on a branch specifically fixing whitespace issues
-          if [[ "${BRANCH_NAME}" == *"fix-trailing-whitespace"* ]]; then
-            echo "::warning::On branch ${BRANCH_NAME} which is fixing whitespace issues - allowing pre-commit failures related to whitespace"
+          if [[ "${BRANCH_NAME}" == *"fix-trailing-whitespace"* ]]; then  echo "::warning::On branch ${BRANCH_NAME} which is fixing whitespace issues - allowing pre-commit failures related to whitespace"
             exit 0  # Always succeed on whitespace-fixing branches
           fi
-          
+
           # Check if there are any failures in the log
           if [ "${FAILED_COUNT}" -gt 0 ]; then
             # If all failures are just "files were modified" messages, consider it a success

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -55,7 +55,8 @@ jobs:
           # Get the current branch name
           BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
           # Check if we're on a branch specifically fixing whitespace issues
-          if [[ "${BRANCH_NAME}" == *"fix-trailing-whitespace"* ]]; then  echo "::warning::On branch ${BRANCH_NAME} which is fixing whitespace issues - allowing pre-commit failures related to whitespace"
+          if [[ "${BRANCH_NAME}" == *"fix-trailing-whitespace"* ]]; then
+            echo "::warning::On branch ${BRANCH_NAME} which is fixing whitespace issues - allowing pre-commit failures related to whitespace"
             exit 0  # Always succeed on whitespace-fixing branches
           fi
 

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -58,7 +58,7 @@ jobs:
           if [[ "${BRANCH_NAME}" == *"fix-trailing-whitespace"* ]]; then  echo "::warning::On branch ${BRANCH_NAME} which is fixing whitespace issues - allowing pre-commit failures related to whitespace"
             exit 0  # Always succeed on whitespace-fixing branches
           fi
-          
+
           # Check if there are any failures in the log
           if [ "${FAILED_COUNT}" -gt 0 ]; then
             # If all failures are just "files were modified" messages, consider it a success

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -54,10 +54,8 @@ jobs:
 
           # Get the current branch name
           BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-          
           # Check if we're on a branch specifically fixing whitespace issues
-          if [[ "${BRANCH_NAME}" == *"fix-trailing-whitespace"* ]]; then
-            echo "::warning::On branch ${BRANCH_NAME} which is fixing whitespace issues - allowing pre-commit failures related to whitespace"
+          if [[ "${BRANCH_NAME}" == *"fix-trailing-whitespace"* ]]; then  echo "::warning::On branch ${BRANCH_NAME} which is fixing whitespace issues - allowing pre-commit failures related to whitespace"
             exit 0  # Always succeed on whitespace-fixing branches
           fi
           


### PR DESCRIPTION
This PR fixes the failing pre-commit workflow by removing trailing whitespace from lines 57 and 63 in the .github/workflows/pre-commit.yml file.

## Root Cause
The yamllint pre-commit hook was detecting trailing whitespace in the workflow file itself, causing the workflow to fail with the following errors:
- Line 57:1 [trailing-spaces] trailing spaces
- Line 63:1 [trailing-spaces] trailing spaces

## Fix
- Removed trailing whitespace from line 57
- Fixed the formatting by properly indenting the echo command on a new line

This should resolve the pre-commit workflow failures and allow the CI checks to pass.