### PR TITLE
Fix branch name detection in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -52,9 +52,17 @@ jobs:
           echo "First few lines of log file:"
           head -n 5 ${RAW_LOG}
 
-          # Get the current branch name
-          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-
+          # Get the current branch name from GitHub environment variables
+          if [[ -n "$GITHUB_HEAD_REF" ]]; then
+            # For pull requests, GITHUB_HEAD_REF contains the source branch name
+            BRANCH_NAME=$GITHUB_HEAD_REF
+          else
+            # For direct pushes, extract branch name from GITHUB_REF
+            BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          fi
+          
+          echo "Detected branch name: ${BRANCH_NAME}"
+          
           # Check if we're on a branch specifically fixing whitespace issues
           if [[ "${BRANCH_NAME}" == *"fix-trailing-whitespace"* ]]; then
             echo "::warning::On branch ${BRANCH_NAME} which is fixing whitespace issues - allowing pre-commit failures related to whitespace"

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -54,13 +54,12 @@ jobs:
 
           # Get the current branch name
           BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-          
+
           # Check if we're on a branch specifically fixing whitespace issues
           if [[ "${BRANCH_NAME}" == *"fix-trailing-whitespace"* ]]; then
             echo "::warning::On branch ${BRANCH_NAME} which is fixing whitespace issues - allowing pre-commit failures related to whitespace"
             exit 0  # Always succeed on whitespace-fixing branches
           fi
-          
           # Check if there are any failures in the log
           if [ "${FAILED_COUNT}" -gt 0 ]; then
             # If all failures are just "files were modified" messages, consider it a success


### PR DESCRIPTION
This PR fixes the branch name detection in the pre-commit workflow.

## Issue
The workflow was failing because `git rev-parse --abbrev-ref HEAD` often returns `HEAD` instead of the actual branch name in GitHub Actions due to the checkout being in a detached HEAD state.

## Solution
Modified the workflow to use GitHub Actions environment variables (`GITHUB_HEAD_REF` and `GITHUB_REF`) to correctly detect the branch name, ensuring that branches with 'fix-trailing-whitespace' in their name are properly identified and allowed to pass even with pre-commit hook modifications.