### PR TITLE
Fix branch name detection in GitHub Actions workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -52,8 +52,14 @@ jobs:
           echo "First few lines of log file:"
           head -n 5 ${RAW_LOG}
 
-          # Get the current branch name
-          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+          # Get the current branch name using GitHub Actions environment variables
+          # For pull request events, use GITHUB_HEAD_REF
+          # For push events, use GITHUB_REF_NAME
+          if [ -n "${GITHUB_HEAD_REF}" ]; then
+            BRANCH_NAME="${GITHUB_HEAD_REF}"
+          else
+            BRANCH_NAME="${GITHUB_REF_NAME}"
+          fi
           echo "Current branch name: ${BRANCH_NAME}"
           # Debug output for regex pattern matching
           echo "Debug: Checking if branch matches formatting-fixing criteria"


### PR DESCRIPTION
This PR fixes the issue with branch name detection in GitHub Actions workflow.

## Problem
In GitHub Actions, when checking out a specific commit (which is what happens by default), Git is in a "detached HEAD" state rather than on a named branch. The `git rev-parse --abbrev-ref HEAD` command in this state returns `HEAD` instead of the actual branch name.

## Solution
Modified the workflow to use GitHub Actions environment variables:
- `GITHUB_HEAD_REF` for pull request events
- `GITHUB_REF_NAME` for push events

This ensures that the workflow correctly identifies branches that are fixing formatting issues and allows them to pass even if pre-commit hooks report "files were modified" failures.

## Testing
The script has been validated for syntax correctness.