### PR TITLE
Fix indentation and trailing spaces in pattern matching logic

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -84,20 +84,19 @@ jobs:
             echo "Branch name to match: ${BRANCH_NAME}"
             # Convert branch name to lowercase for case-insensitive matching
             BRANCH_NAME_LOWER=$(echo "${BRANCH_NAME}" | tr '[:upper:]' '[:lower:]')
-            
             # Check for each keyword using bash pattern matching
-            if [[ "${BRANCH_NAME_LOWER}" == *pattern* || 
-                  "${BRANCH_NAME_LOWER}" == *regex* || 
-                  "${BRANCH_NAME_LOWER}" == *trailing-whitespace* || 
-                  "${BRANCH_NAME_LOWER}" == *formatting* || 
+            if [[ "${BRANCH_NAME_LOWER}" == *pattern* || \
+                  "${BRANCH_NAME_LOWER}" == *regex* || \
+                  "${BRANCH_NAME_LOWER}" == *trailing-whitespace* || \
+                  "${BRANCH_NAME_LOWER}" == *formatting* || \
                   "${BRANCH_NAME_LOWER}" == *branch-detection* ]]; then
               echo "Branch contains formatting keywords: YES"
-            echo "Matched keyword(s):"
-            for keyword in "pattern" "regex" "trailing-whitespace" "formatting" "branch-detection"; do
-              if [[ "${BRANCH_NAME_LOWER}" == *"${keyword}"* ]]; then
-                echo "- ${keyword}"
-              fi
-            done
+              echo "Matched keyword(s):"
+              for keyword in "pattern" "regex" "trailing-whitespace" "formatting" "branch-detection"; do
+                if [[ "${BRANCH_NAME_LOWER}" == *"${keyword}"* ]]; then
+                  echo "- ${keyword}"
+                fi
+              done
               echo "::warning::On branch ${BRANCH_NAME} which is fixing formatting issues - allowing pre-commit failures related to formatting"
               exit 0  # Always succeed on formatting-fixing branches
             else

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -86,12 +86,18 @@ jobs:
             BRANCH_NAME_LOWER=$(echo "${BRANCH_NAME}" | tr '[:upper:]' '[:lower:]')
             
             # Check for each keyword using bash pattern matching
-            if [[ "${BRANCH_NAME_LOWER}" == *pattern* || 
-                  "${BRANCH_NAME_LOWER}" == *regex* || 
-                  "${BRANCH_NAME_LOWER}" == *trailing-whitespace* || 
-                  "${BRANCH_NAME_LOWER}" == *formatting* || 
+            if [[ "${BRANCH_NAME_LOWER}" == *pattern* || \
+                  "${BRANCH_NAME_LOWER}" == *regex* || \
+                  "${BRANCH_NAME_LOWER}" == *trailing-whitespace* || \
+                  "${BRANCH_NAME_LOWER}" == *formatting* || \
                   "${BRANCH_NAME_LOWER}" == *branch-detection* ]]; then
               echo "Branch contains formatting keywords: YES"
+              echo "Matched keyword(s):"
+              for keyword in "pattern" "regex" "trailing-whitespace" "formatting" "branch-detection"; do
+                if [[ "${BRANCH_NAME_LOWER}" == *"${keyword}"* ]]; then
+                  echo "- ${keyword}"
+                fi
+              done
               echo "::warning::On branch ${BRANCH_NAME} which is fixing formatting issues - allowing pre-commit failures related to formatting"
               exit 0  # Always succeed on formatting-fixing branches
             else


### PR DESCRIPTION
This PR fixes the indentation error in the bash script within the `.github/workflows/pre-commit.yml` file, specifically in the pattern matching logic section.

The following issues were fixed:
1. Corrected indentation for the `echo "Matched keyword(s):"` line and the following for loop, which were incorrectly at the same indentation level as the `echo "Branch contains formatting keywords: YES"` line
2. Removed trailing spaces at the end of lines that were causing yamllint errors
3. Added backslashes at line continuations to maintain proper YAML formatting

These changes ensure that the conditional logic executes correctly, allowing the branch name pattern matching to work as expected for branches that are fixing formatting issues.