### PR TITLE
Fix trailing whitespace in pre-commit workflow pattern matching

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,12 +94,12 @@ jobs:
             echo "Lowercase branch name: ${BRANCH_NAME_LOWER}"
             # Use bash pattern matching which is more reliable than grep in GitHub Actions environment
             # Modified to check for partial matches using substring checks
-            if [[ "$BRANCH_NAME_LOWER" == *pattern* ]] || 
-               [[ "$BRANCH_NAME_LOWER" == *regex* ]] || 
-               [[ "$BRANCH_NAME_LOWER" == *trailing* ]] || 
-               [[ "$BRANCH_NAME_LOWER" == *whitespace* ]] || 
-               [[ "$BRANCH_NAME_LOWER" == *format* ]] || 
-               [[ "$BRANCH_NAME_LOWER" == *branch* ]] || 
+            if [[ "$BRANCH_NAME_LOWER" == *pattern* ]] ||
+               [[ "$BRANCH_NAME_LOWER" == *regex* ]] ||
+               [[ "$BRANCH_NAME_LOWER" == *trailing* ]] ||
+               [[ "$BRANCH_NAME_LOWER" == *whitespace* ]] ||
+               [[ "$BRANCH_NAME_LOWER" == *format* ]] ||
+               [[ "$BRANCH_NAME_LOWER" == *branch* ]] ||
                [[ "$BRANCH_NAME_LOWER" == *detect* ]]; then
               echo "Branch contains formatting keywords: YES"
               echo "::warning::On branch ${BRANCH_NAME} which is fixing formatting issues - allowing pre-commit failures related to formatting"

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -78,7 +78,7 @@ jobs:
             echo "Branch starts with 'fix-': YES"
             # Check for keywords in the branch name with debug output
             # Using bash pattern matching instead of grep for more reliable substring matching
-            echo "Checking if branch contains any of these keywords (including within hyphenated words): pattern, regex, trailing-whitespace, formatting, branch-detection"
+            echo "Checking if branch contains any of these keywords or their parts (including within hyphenated words): pattern, regex, trailing, whitespace, format, branch, detect"
             # Using grep with extended regex (-E) for more reliable pattern matching with multiple keywords
             # This approach is more robust against potential environment-specific issues in GitHub Actions
             # The -E flag allows us to use the pipe character (|) directly without escaping


### PR DESCRIPTION
This PR fixes the trailing whitespace issues in the pre-commit.yml workflow file that were causing the yamllint check to fail.

The issue was in the pattern matching logic that checks for formatting-related keywords in branch names. Each line in the multi-line if condition had trailing spaces after the `||` operator, which caused the yamllint check to fail.

These trailing spaces have been removed while preserving the functionality of the pattern matching logic.

This fix addresses the root cause of the workflow failure and ensures that branches with formatting-related keywords in their names are properly identified.