### PR TITLE
Fix: Remove trailing whitespace in pre-commit.yml

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -33,7 +33,7 @@ jobs:
           set -o pipefail
           # Initialize a flag to track whether we should skip failure checks
           SKIP_FAILURE_CHECKS=false
-          
+
           # Clean pre-commit cache to remove phantom files
           pre-commit clean
           pre-commit gc


### PR DESCRIPTION
This PR fixes the workflow failure by removing trailing whitespace at the end of line 36 in the `.github/workflows/pre-commit.yml` file.

The issue was causing the yamllint pre-commit hook to fail with the error `36:1 [trailing-spaces] trailing spaces`.

The fix is minimal and only removes the trailing whitespace characters after the comment text "# Clean pre-commit cache to remove phantom files".