### PR TITLE
Fix workflow exit code handling for formatting fix branches

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -135,6 +135,8 @@ jobs:
             fi
           elif [ "$SKIP_FAILURE_CHECKS" = true ]; then
             echo "::notice::Skipping failure checks because this is a formatting fix branch"
+            # Reset exit code to 0 to prevent workflow failure when we're on a formatting fix branch
+            exit 0
           fi
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5


### PR DESCRIPTION
This PR fixes the issue with the pre-commit workflow failing on formatting fix branches.

## Root Cause
The workflow correctly identifies branches that are fixing formatting issues and sets `SKIP_FAILURE_CHECKS=true`, but it doesn't reset the exit code from the pre-commit command. This causes the workflow to fail even though it should be allowing formatting-related failures on these branches.

## Solution
Added an `exit 0` statement in the conditional block that handles formatting fix branches to ensure the workflow succeeds when `SKIP_FAILURE_CHECKS` is true, regardless of the pre-commit command's exit code.