### PR TITLE
Fix pre-commit workflow by adding explicit exit 0 statements

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -120,7 +120,8 @@ jobs:
             # If all failures are just "files were modified" messages, consider it a success
             if [ "${FAILED_COUNT}" -eq "${MODIFIED_COUNT}" ]; then
               echo "::warning::Pre-commit reported 'Failed' but these were just 'files were modified' messages"
-              # Success - no need to exit
+              # Explicitly exit with success code when all failures are just "files were modified"
+              exit 0
             # If we have actual errors (failures without "files were modified"), exit with error
             elif [ "${MODIFIED_COUNT}" -eq 0 ]; then
               echo "::error::Pre-commit found actual issues that need to be fixed"
@@ -131,7 +132,8 @@ jobs:
               exit 1
             else
               echo "::warning::Pre-commit reported 'files were modified' but no actual errors were found"
-              # Success - no need to exit
+              # Explicitly exit with success code when no actual errors are found
+              exit 0
             fi
           elif [ "$SKIP_FAILURE_CHECKS" = true ]; then
             echo "::notice::Skipping failure checks because this is a formatting fix branch"

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -120,7 +120,8 @@ jobs:
             # If all failures are just "files were modified" messages, consider it a success
             if [ "${FAILED_COUNT}" -eq "${MODIFIED_COUNT}" ]; then
               echo "::warning::Pre-commit reported 'Failed' but these were just 'files were modified' messages"
-              # Success - no need to exit
+              # Explicitly exit with success code when all failures are just "files were modified"
+              exit 0
             # If we have actual errors (failures without "files were modified"), exit with error
             elif [ "${MODIFIED_COUNT}" -eq 0 ]; then
               echo "::error::Pre-commit found actual issues that need to be fixed"
@@ -135,6 +136,7 @@ jobs:
             fi
           elif [ "$SKIP_FAILURE_CHECKS" = true ]; then
             echo "::notice::Skipping failure checks because this is a formatting fix branch"
+            exit 0  # Explicitly exit with success code for formatting fix branches
           fi
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5


### PR DESCRIPTION
This PR fixes the pre-commit workflow by adding explicit `exit 0` statements when all failures are just "files were modified" messages.

The root cause of the workflow failure was that the script correctly identified when all failures were just "files were modified" messages but didn't explicitly set a success exit code, causing the workflow to fail.

Changes made:
1. Added `exit 0` after the warning message when all failures are "files were modified" messages
2. Added `exit 0` after the warning message when no actual errors are found

This ensures that the workflow will properly succeed when there are no actual errors, only "files were modified" messages.