### PR TITLE
Fix variable ordering issue in pre-commit workflow script

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -84,6 +84,9 @@ jobs:
             # The -E flag allows us to use the pipe character (|) directly without escaping
             # Add debug output to help diagnose pattern matching issues
             echo "Branch name to match: ${BRANCH_NAME}"
+            # Convert branch name to lowercase for case-insensitive matching
+            BRANCH_NAME_LOWER=$(echo "${BRANCH_NAME}" | tr '[:upper:]' '[:lower:]')
+            
             # Debug output to show what we're matching against
             echo "Testing bash regex pattern match (case-insensitive):"
             if [[ ${BRANCH_NAME_LOWER} =~ (pattern|regex|grep|trailing-whitespace|formatting|branch-detection) ]]; then
@@ -94,8 +97,6 @@ jobs:
             # Use bash's built-in regex matching for more reliable pattern matching across environments
             # This avoids potential issues with grep and quoting in different shell environments
             # When using =~ operator in bash, the regex pattern should not be quoted
-            # Convert branch name to lowercase for case-insensitive matching
-            BRANCH_NAME_LOWER=$(echo "${BRANCH_NAME}" | tr '[:upper:]' '[:lower:]')
             if [[ ${BRANCH_NAME_LOWER} =~ (pattern|regex|grep|trailing-whitespace|formatting|branch-detection) ]]; then
               echo "Branch contains formatting keywords: YES"
               echo "::warning::On branch ${BRANCH_NAME} which is fixing formatting issues - allowing pre-commit failures related to formatting"

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -85,8 +85,8 @@ jobs:
             # Add debug output to help diagnose pattern matching issues
             echo "Branch name to match: ${BRANCH_NAME}"
             # Debug output to show what we're matching against
-            echo "Testing bash regex pattern match:"
-            if [[ ${BRANCH_NAME} =~ (pattern|regex|grep|trailing-whitespace|formatting|branch-detection) ]]; then
+            echo "Testing bash regex pattern match (case-insensitive):"
+            if [[ ${BRANCH_NAME_LOWER} =~ (pattern|regex|grep|trailing-whitespace|formatting|branch-detection) ]]; then
               echo "Match found: ${BASH_REMATCH[0]}"
             else
               echo "No match found"


### PR DESCRIPTION
This PR fixes the issue in the pre-commit workflow where the variable `BRANCH_NAME_LOWER` was being used before it was defined.

The root cause of the workflow failure was that the script was trying to use `BRANCH_NAME_LOWER` in a conditional check before the variable was defined. This caused the pattern matching to fail, preventing the workflow from recognizing that the branch is a formatting-fix branch.

Changes made:
1. Moved the definition of `BRANCH_NAME_LOWER` before its first use in the conditional check
2. Removed redundant comments that were now out of place

This fix ensures that branches with formatting-related keywords in their names (like "fix-grep-pattern-matching") are properly identified, allowing pre-commit failures related to formatting to be bypassed as intended.