### PR TITLE
Fix variable ordering issue in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -84,6 +84,9 @@ jobs:
             # The -E flag allows us to use the pipe character (|) directly without escaping
             # Add debug output to help diagnose pattern matching issues
             echo "Branch name to match: ${BRANCH_NAME}"
+            # Convert branch name to lowercase for case-insensitive matching
+            BRANCH_NAME_LOWER=$(echo "${BRANCH_NAME}" | tr '[:upper:]' '[:lower:]')
+            
             # Debug output to show what we're matching against
             echo "Testing bash regex pattern match (case-insensitive):"
             if [[ ${BRANCH_NAME_LOWER} =~ (pattern|regex|grep|trailing-whitespace|formatting|branch-detection) ]]; then
@@ -94,8 +97,6 @@ jobs:
             # Use bash's built-in regex matching for more reliable pattern matching across environments
             # This avoids potential issues with grep and quoting in different shell environments
             # When using =~ operator in bash, the regex pattern should not be quoted
-            # Convert branch name to lowercase for case-insensitive matching
-            BRANCH_NAME_LOWER=$(echo "${BRANCH_NAME}" | tr '[:upper:]' '[:lower:]')
             if [[ ${BRANCH_NAME_LOWER} =~ (pattern|regex|grep|trailing-whitespace|formatting|branch-detection) ]]; then
               echo "Branch contains formatting keywords: YES"
               echo "::warning::On branch ${BRANCH_NAME} which is fixing formatting issues - allowing pre-commit failures related to formatting"

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -85,8 +85,8 @@ jobs:
             # Add debug output to help diagnose pattern matching issues
             echo "Branch name to match: ${BRANCH_NAME}"
             # Debug output to show what we're matching against
-            echo "Testing bash regex pattern match:"
-            if [[ ${BRANCH_NAME} =~ (pattern|regex|grep|trailing-whitespace|formatting|branch-detection) ]]; then
+            echo "Testing bash regex pattern match (case-insensitive):"
+            if [[ ${BRANCH_NAME_LOWER} =~ (pattern|regex|grep|trailing-whitespace|formatting|branch-detection) ]]; then
               echo "Match found: ${BASH_REMATCH[0]}"
             else
               echo "No match found"

--- a/test_fix.sh
+++ b/test_fix.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Set up test environment
+BRANCH_NAME="fix-grep-pattern-matching"
+echo "Testing with branch name: ${BRANCH_NAME}"
+
+# Convert branch name to lowercase for case-insensitive matching
+BRANCH_NAME_LOWER=$(echo "${BRANCH_NAME}" | tr '[:upper:]' '[:lower:]')
+
+# Debug output to show what we're matching against
+echo "Testing bash regex pattern match (case-insensitive):"
+if [[ ${BRANCH_NAME_LOWER} =~ (pattern|regex|grep|trailing-whitespace|formatting|branch-detection) ]]; then
+  echo "Match found: ${BASH_REMATCH[0]}"
+else
+  echo "No match found"
+fi
+
+echo "Test completed successfully!"


### PR DESCRIPTION
This PR fixes the variable ordering issue in the pre-commit workflow that was causing the branch name pattern matching to fail.

## Root Cause
The variable `BRANCH_NAME_LOWER` was being used before it was defined in the script. When an undefined variable is used in a bash regex pattern matching operation, it's treated as an empty string, causing the pattern matching to fail.

## Solution
Moved the definition of `BRANCH_NAME_LOWER` before it's used in the conditional check. This ensures that the variable is properly initialized with the lowercase branch name before the pattern matching is performed.

## Testing
Verified locally that the pattern matching now correctly identifies keywords in the branch name.