### PR TITLE
Fix bash execution environment issue in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,7 +29,13 @@ jobs:
           path: ~/.cache/pre-commit/
           key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml', '.pre-commit-config-ci.yaml') }}
       - name: Run pre-commit hooks
+        # Note: We use 'set +e' to prevent the script from exiting immediately when
+        # pre-commit fails, allowing us to properly handle fix-* branches that are
+        # expected to have pre-commit failures. We capture the exit code using PIPESTATUS
+        # to still be able to check if pre-commit failed.
         run: |
+          # Disable exit on error to prevent early termination
+          set +e
           set -o pipefail
           # Initialize a flag to track whether we should skip failure checks
           SKIP_FAILURE_CHECKS=false
@@ -42,6 +48,8 @@ jobs:
           touch ${RAW_LOG}
           # Run pre-commit on all files in check-only mode and ensure output is captured
           pre-commit run --show-diff-on-failure --color=always --all-files -c .pre-commit-config-ci.yaml | tee ${RAW_LOG}
+          # Capture the exit code
+          PRE_COMMIT_EXIT_CODE=${PIPESTATUS[0]}
 
           # Count the number of failures and "files were modified" messages
           FAILED_COUNT=$(grep -c "Failed" ${RAW_LOG} || echo 0)
@@ -91,7 +99,8 @@ jobs:
             # Reset exit code to 0 to prevent workflow failure when we're on a formatting fix branch
             exit 0
           # Only then check for failures if we're not skipping checks
-          elif [ "${FAILED_COUNT}" -gt 0 ]; then
+          elif [ "${PRE_COMMIT_EXIT_CODE}" -ne 0 ] || [ "${FAILED_COUNT}" -gt 0 ]; then
+            echo "Pre-commit exit code: ${PRE_COMMIT_EXIT_CODE}"
             # If all failures are just "files were modified" messages, consider it a success
             if [ "${FAILED_COUNT}" -eq "${MODIFIED_COUNT}" ]; then
               echo "::warning::Pre-commit reported 'Failed' but these were just 'files were modified' messages"

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -30,6 +30,8 @@ jobs:
           key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml', '.pre-commit-config-ci.yaml') }}
       - name: Run pre-commit hooks
         run: |
+          # Disable exit on error to prevent early termination
+          set +e
           set -o pipefail
           # Initialize a flag to track whether we should skip failure checks
           SKIP_FAILURE_CHECKS=false
@@ -42,6 +44,8 @@ jobs:
           touch ${RAW_LOG}
           # Run pre-commit on all files in check-only mode and ensure output is captured
           pre-commit run --show-diff-on-failure --color=always --all-files -c .pre-commit-config-ci.yaml | tee ${RAW_LOG}
+          # Capture the exit code
+          PRE_COMMIT_EXIT_CODE=${PIPESTATUS[0]}
 
           # Count the number of failures and "files were modified" messages
           FAILED_COUNT=$(grep -c "Failed" ${RAW_LOG} || echo 0)
@@ -85,8 +89,14 @@ jobs:
             echo "Branch starts with 'fix-': NO"
           fi
 
-          # Only check for failures if we're not on a formatting fix branch
-          if [ "$SKIP_FAILURE_CHECKS" = false ] && [ "${FAILED_COUNT}" -gt 0 ]; then
+          # First check if we should skip failure checks (for fix-* branches)
+          if [ "$SKIP_FAILURE_CHECKS" = true ]; then
+            echo "::notice::Skipping failure checks because this is a formatting fix branch"
+            # Reset exit code to 0 to prevent workflow failure when we're on a formatting fix branch
+            exit 0
+          # Only then check for failures if we're not skipping checks
+          elif [ "${PRE_COMMIT_EXIT_CODE}" -ne 0 ] || [ "${FAILED_COUNT}" -gt 0 ]; then
+            echo "Pre-commit exit code: ${PRE_COMMIT_EXIT_CODE}"
             # If all failures are just "files were modified" messages, consider it a success
             if [ "${FAILED_COUNT}" -eq "${MODIFIED_COUNT}" ]; then
               echo "::warning::Pre-commit reported 'Failed' but these were just 'files were modified' messages"
@@ -103,10 +113,6 @@ jobs:
               echo "::warning::Pre-commit reported 'files were modified' but no actual errors were found"
               # Success - no need to exit
             fi
-          elif [ "$SKIP_FAILURE_CHECKS" = true ]; then
-            echo "::notice::Skipping failure checks because this is a formatting fix branch"
-            # Reset exit code to 0 to prevent workflow failure when we're on a formatting fix branch
-            exit 0
           fi
       - name: Convert Raw Log to Checkstyle format (launch action)
         uses: mdeweerd/logToCheckStyle@v2024.3.5

--- a/pre-commit.log
+++ b/pre-commit.log
@@ -1,1 +1,3 @@
-Test
+black....................................................................Failed
+- hook id: black
+- files were modified by this hook


### PR DESCRIPTION
This PR fixes the bash execution environment issue in the pre-commit workflow.

## Root Cause
The workflow was failing because the bash script was running with the `-e` flag enabled, which causes the script to exit immediately when any command in a pipeline fails. This was preventing the conditional logic for `fix-*` branches from being evaluated.

## Solution
1. Added `set +e` to disable the exit-on-error behavior at the beginning of the script
2. Captured the pre-commit exit code using `${PIPESTATUS[0]}` to still be able to check if pre-commit failed
3. Modified the conditional logic to check both the exit code and the failure count
4. Added detailed comments explaining the changes

This change ensures that even when pre-commit fails, the script continues execution and properly handles branches that start with `fix-`, allowing the workflow to succeed on these branches as intended.