### PR TITLE
Fix pre-commit workflow variable comparison logic

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -44,6 +44,16 @@ jobs:
           FAILED_COUNT=$(grep -c "Failed" ${RAW_LOG} || echo 0)
           MODIFIED_COUNT=$(grep -c "files were modified by this hook" ${RAW_LOG} || echo 0)
           ERROR_COUNT=$(grep -c "^[^-].*error:" ${RAW_LOG} || echo 0)
+          
+          # Ensure variables are numeric to prevent comparison issues
+          FAILED_COUNT=$(echo "${FAILED_COUNT}" | tr -d '[:space:]')
+          MODIFIED_COUNT=$(echo "${MODIFIED_COUNT}" | tr -d '[:space:]')
+          ERROR_COUNT=$(echo "${ERROR_COUNT}" | tr -d '[:space:]')
+          
+          # Set default values if empty
+          FAILED_COUNT=${FAILED_COUNT:-0}
+          MODIFIED_COUNT=${MODIFIED_COUNT:-0}
+          ERROR_COUNT=${ERROR_COUNT:-0}
 
           echo "Found ${FAILED_COUNT} failures, ${MODIFIED_COUNT} 'files were modified' messages, and ${ERROR_COUNT} errors"
 
@@ -127,18 +137,23 @@ jobs:
             echo "Branch starts with 'fix-': NO"
           fi
 
+          # Debug output for variable values to help with troubleshooting
+          echo "FAILED_COUNT=${FAILED_COUNT} (type: $([ "${FAILED_COUNT}" -eq "${FAILED_COUNT}" ] 2>/dev/null && echo "numeric" || echo "non-numeric"))"
+          echo "MODIFIED_COUNT=${MODIFIED_COUNT} (type: $([ "${MODIFIED_COUNT}" -eq "${MODIFIED_COUNT}" ] 2>/dev/null && echo "numeric" || echo "non-numeric"))"
+          echo "ERROR_COUNT=${ERROR_COUNT} (type: $([ "${ERROR_COUNT}" -eq "${ERROR_COUNT}" ] 2>/dev/null && echo "numeric" || echo "non-numeric"))"
+          
           # Check if there are any failures in the log
-          if [ "${FAILED_COUNT}" -gt 0 ]; then
+          if [[ "${FAILED_COUNT}" =~ ^[0-9]+$ ]] && [ "${FAILED_COUNT}" -gt 0 ]; then
             # If all failures are just "files were modified" messages, consider it a success
-            if [ "${FAILED_COUNT}" -eq "${MODIFIED_COUNT}" ]; then
+            if [[ "${MODIFIED_COUNT}" =~ ^[0-9]+$ ]] && [ "${FAILED_COUNT}" -eq "${MODIFIED_COUNT}" ]; then
               echo "::warning::Pre-commit reported 'Failed' but these were just 'files were modified' messages"
               exit 0  # Explicitly set success exit code
             # If we have actual errors (failures without "files were modified"), exit with error
-            elif [ "${MODIFIED_COUNT}" -eq 0 ]; then
+            elif [[ "${MODIFIED_COUNT}" =~ ^[0-9]+$ ]] && [ "${MODIFIED_COUNT}" -eq 0 ]; then
               echo "::error::Pre-commit found actual issues that need to be fixed"
               exit 1
             # If we have a mix of "files were modified" and other failures, check for actual errors
-            elif [ "${ERROR_COUNT}" -gt 0 ]; then
+            elif [[ "${ERROR_COUNT}" =~ ^[0-9]+$ ]] && [ "${ERROR_COUNT}" -gt 0 ]; then
               echo "::error::Pre-commit found actual errors that need to be fixed"
               exit 1
             else

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -44,6 +44,16 @@ jobs:
           FAILED_COUNT=$(grep -c "Failed" ${RAW_LOG} || echo 0)
           MODIFIED_COUNT=$(grep -c "files were modified by this hook" ${RAW_LOG} || echo 0)
           ERROR_COUNT=$(grep -c "^[^-].*error:" ${RAW_LOG} || echo 0)
+          
+          # Ensure variables are numeric to prevent comparison issues
+          FAILED_COUNT=$(echo "${FAILED_COUNT}" | tr -d '[:space:]')
+          MODIFIED_COUNT=$(echo "${MODIFIED_COUNT}" | tr -d '[:space:]')
+          ERROR_COUNT=$(echo "${ERROR_COUNT}" | tr -d '[:space:]')
+          
+          # Set default values if empty
+          FAILED_COUNT=${FAILED_COUNT:-0}
+          MODIFIED_COUNT=${MODIFIED_COUNT:-0}
+          ERROR_COUNT=${ERROR_COUNT:-0}
 
           echo "Found ${FAILED_COUNT} failures, ${MODIFIED_COUNT} 'files were modified' messages, and ${ERROR_COUNT} errors"
 
@@ -94,8 +104,6 @@ jobs:
             # 2. Simplified regex patterns without special characters like [-.]
             # 3. Case-insensitive grep matching with -i flag
             # 4. Multiple fallback mechanisms to ensure proper detection
-            # 5. Improved handling of hyphenated words by converting hyphens to spaces
-            # 6. Word boundary matching to detect keywords within hyphenated words
             # 5. Improved handling of hyphenated words by converting hyphens to spaces
             # 6. Word boundary matching to detect keywords within hyphenated words
 

--- a/test/pre-commit.log
+++ b/test/pre-commit.log
@@ -1,0 +1,7 @@
+[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
+black....................................................................Failed
+- hook id: black
+- files were modified by this hook
+mypy.....................................................................Failed
+- hook id: mypy
+- files were modified by this hook

--- a/test/test_script.sh
+++ b/test/test_script.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+# Setup test environment
+RAW_LOG="test/pre-commit.log"
+echo "[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks." > ${RAW_LOG}
+echo "black....................................................................Failed" >> ${RAW_LOG}
+echo "- hook id: black" >> ${RAW_LOG}
+echo "- files were modified by this hook" >> ${RAW_LOG}
+echo "mypy.....................................................................Failed" >> ${RAW_LOG}
+echo "- hook id: mypy" >> ${RAW_LOG}
+echo "- files were modified by this hook" >> ${RAW_LOG}
+
+# Count the number of failures and "files were modified" messages
+FAILED_COUNT=$(grep -c "Failed" ${RAW_LOG} || echo 0)
+MODIFIED_COUNT=$(grep -c "files were modified by this hook" ${RAW_LOG} || echo 0)
+ERROR_COUNT=$(grep -c "^[^-].*error:" ${RAW_LOG} || echo 0)
+
+# Ensure variables are numeric to prevent comparison issues
+FAILED_COUNT=$(echo "${FAILED_COUNT}" | tr -d '[:space:]')
+MODIFIED_COUNT=$(echo "${MODIFIED_COUNT}" | tr -d '[:space:]')
+ERROR_COUNT=$(echo "${ERROR_COUNT}" | tr -d '[:space:]')
+
+# Set default values if empty
+FAILED_COUNT=${FAILED_COUNT:-0}
+MODIFIED_COUNT=${MODIFIED_COUNT:-0}
+ERROR_COUNT=${ERROR_COUNT:-0}
+
+echo "Found ${FAILED_COUNT} failures, ${MODIFIED_COUNT} 'files were modified' messages, and ${ERROR_COUNT} errors"
+
+# Debug output for variable values to help with troubleshooting
+echo "FAILED_COUNT=${FAILED_COUNT} (type: $([ "${FAILED_COUNT}" -eq "${FAILED_COUNT}" ] 2>/dev/null && echo "numeric" || echo "non-numeric"))"
+echo "MODIFIED_COUNT=${MODIFIED_COUNT} (type: $([ "${MODIFIED_COUNT}" -eq "${MODIFIED_COUNT}" ] 2>/dev/null && echo "numeric" || echo "non-numeric"))"
+echo "ERROR_COUNT=${ERROR_COUNT} (type: $([ "${ERROR_COUNT}" -eq "${ERROR_COUNT}" ] 2>/dev/null && echo "numeric" || echo "non-numeric"))"
+
+# Check if there are any failures in the log
+if [[ "${FAILED_COUNT}" =~ ^[0-9]+$ ]] && [ "${FAILED_COUNT}" -gt 0 ]; then
+  # If all failures are just "files were modified" messages, consider it a success
+  if [[ "${MODIFIED_COUNT}" =~ ^[0-9]+$ ]] && [ "${FAILED_COUNT}" -eq "${MODIFIED_COUNT}" ]; then
+    echo "::warning::Pre-commit reported 'Failed' but these were just 'files were modified' messages"
+    echo "TEST PASSED: Would exit with success code 0"
+  # If we have actual errors (failures without "files were modified"), exit with error
+  elif [[ "${MODIFIED_COUNT}" =~ ^[0-9]+$ ]] && [ "${MODIFIED_COUNT}" -eq 0 ]; then
+    echo "::error::Pre-commit found actual issues that need to be fixed"
+    echo "TEST FAILED: Would exit with error code 1"
+  # If we have a mix of "files were modified" and other failures, check for actual errors
+  elif [[ "${ERROR_COUNT}" =~ ^[0-9]+$ ]] && [ "${ERROR_COUNT}" -gt 0 ]; then
+    echo "::error::Pre-commit found actual errors that need to be fixed"
+    echo "TEST FAILED: Would exit with error code 1"
+  else
+    echo "::warning::Pre-commit reported 'files were modified' but no actual errors were found"
+    echo "TEST PASSED: Would exit with success code 0"
+  fi
+else
+  echo "No failures found"
+  echo "TEST PASSED: Would continue execution"
+fi


### PR DESCRIPTION
This PR fixes the issue in the pre-commit workflow where the condition to check if all failures are just "files were modified" messages was not working correctly.

## Changes:
1. Added proper variable sanitization to ensure numeric values for comparison:
   - Trimming whitespace from grep results
   - Setting default values if empty
   - Ensuring variables are numeric before comparison

2. Added more robust comparison logic:
   - Using regex pattern matching to verify variables are numeric
   - Adding explicit type checking for variables
   - Adding debug output for variable values to help with troubleshooting

3. Improved error handling:
   - Better handling of edge cases where variables might be empty or non-numeric
   - More informative debug output

This fix ensures that when all pre-commit failures are just "files were modified" messages (as in the case of the fix-hyphenated-keywords branch), the workflow will correctly exit with success code 0.