### PR TITLE
Fix trailing whitespace in pre-commit.yml workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -143,7 +143,7 @@ jobs:
                 fi
               done
             fi
-            
+
             # Summary of matching results
             if [[ "$MATCH_FOUND" == "true" ]]; then
               echo "Match found using one of the pattern matching methods"

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -143,6 +143,16 @@ jobs:
                 fi
               done
             fi
+            
+            # Summary of matching results
+            if [[ "$MATCH_FOUND" == "true" ]]; then
+              echo "Match found using one of the pattern matching methods"
+            else
+              echo "No match found with any pattern matching method"
+              # Debug output for troubleshooting
+              echo "Debug: Full branch name: '${BRANCH_NAME}'"
+              echo "Debug: Lowercase branch name: '${BRANCH_NAME_LOWER}'"
+            fi
             # Use the result of our simplified matching
             if [[ "$MATCH_FOUND" == "true" ]]; then
               echo "Branch contains formatting keywords: YES (matched: ${MATCHED_KEYWORD:-'via grep'})"


### PR DESCRIPTION
This PR fixes the pre-commit workflow failure by removing trailing whitespace at line 146, column 1 of the `.github/workflows/pre-commit.yml` file.

The issue was detected by the yamllint pre-commit hook which found trailing spaces after the line containing a closing `fi` statement and before a comment line.

This simple whitespace fix should resolve the CI failure without any functional changes to the workflow.