### PR TITLE
Fix branch name detection in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -57,11 +57,14 @@ jobs:
 
           # Get the branch name from GitHub environment variables
           # For pull requests, GITHUB_HEAD_REF contains the source branch name
-          # For direct pushes, we extract it from GITHUB_REF
-          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-          echo "Current branch name: ${BRANCH_NAME}"
+          # For direct pushes, we use GITHUB_REF_NAME which is more reliable in GitHub Actions
           echo "GITHUB_REF: ${GITHUB_REF}"
           echo "GITHUB_HEAD_REF: ${GITHUB_HEAD_REF}"
+          echo "GITHUB_REF_NAME: ${GITHUB_REF_NAME}"
+          
+          # Use GITHUB_REF_NAME as a more reliable fallback
+          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          echo "Current branch name: ${BRANCH_NAME}"
 
           # Debug branch name character by character to detect any invisible characters
           echo "Branch name character by character:"
@@ -73,7 +76,7 @@ jobs:
           # Check if we're on a branch specifically fixing formatting issues
           # Simplified branch name matching logic to avoid pattern matching issues
           echo "Checking if branch name matches formatting fix pattern..."
-          if [[ ${BRANCH_NAME} =~ ^fix- ]]; then
+          if [[ ${BRANCH_NAME} =~ ^fix- ]] || [[ "${BRANCH_NAME}" == fix-* ]]; then
             echo "Branch starts with 'fix-': YES"
 
             # For branches starting with fix-, we'll automatically consider them as formatting fix branches

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -1,7 +1,7 @@
 name: pre-commit
 # This workflow runs pre-commit checks on all files and handles formatting-specific branches
-# The pattern matching logic has been improved to use native bash string operations instead of grep
-# for more consistent behavior across different environments (local vs GitHub Actions)
+# The pattern matching logic has been simplified to automatically pass any branch starting with "fix-"
+# This avoids complex string matching issues and ensures consistent behavior across environments
 on:
   pull_request:
   push:
@@ -55,13 +55,23 @@ jobs:
           echo "First few lines of log file:"
           head -n 5 ${RAW_LOG}
 
-          # Get the branch name from GitHub environment variables
+          # Get the branch name from GitHub environment variables with improved reliability
           # For pull requests, GITHUB_HEAD_REF contains the source branch name
-          # For direct pushes, we extract it from GITHUB_REF
-          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-          echo "Current branch name: ${BRANCH_NAME}"
+          # For direct pushes, we try multiple GitHub environment variables in order of reliability
+          # GITHUB_REF_NAME is more reliable in GitHub Actions than manually extracting from GITHUB_REF
+          echo "All GitHub ref environment variables:"
           echo "GITHUB_REF: ${GITHUB_REF}"
           echo "GITHUB_HEAD_REF: ${GITHUB_HEAD_REF}"
+          echo "GITHUB_REF_NAME: ${GITHUB_REF_NAME}"
+          echo "GITHUB_BASE_REF: ${GITHUB_BASE_REF}"
+          
+          # Use GITHUB_REF_NAME as a more reliable fallback than parsing GITHUB_REF
+          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          # If both are empty, fall back to the old method as last resort
+          if [ -z "${BRANCH_NAME}" ]; then
+            BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          fi
+          echo "Current branch name: ${BRANCH_NAME}"
 
           # Debug branch name character by character to detect any invisible characters
           echo "Branch name character by character:"
@@ -71,13 +81,11 @@ jobs:
           done
 
           # Check if we're on a branch specifically fixing formatting issues
-          # Simplified branch name matching logic to avoid pattern matching issues
           echo "Checking if branch name matches formatting fix pattern..."
-          if [[ ${BRANCH_NAME} =~ ^fix- ]]; then
+          
+          # Use both regex pattern matching and string prefix check for better reliability
+          if [[ ${BRANCH_NAME} =~ ^fix- ]] || [[ "${BRANCH_NAME}" == fix-* ]]; then
             echo "Branch starts with 'fix-': YES"
-            
-            # For branches starting with fix-, we'll automatically consider them as formatting fix branches
-            # This simplifies the logic and avoids pattern matching issues
             echo "::warning::On branch ${BRANCH_NAME} which is fixing formatting issues - allowing pre-commit failures related to formatting"
             exit 0  # Always succeed on formatting-fixing branches
           else


### PR DESCRIPTION
This PR fixes the branch name detection in the pre-commit workflow by:

1. Using `GITHUB_REF_NAME` as a more reliable fallback instead of manually parsing `GITHUB_REF`
2. Adding a string prefix check (`[[ "${BRANCH_NAME}" == fix-* ]]`) as a fallback to the regex pattern matching

These changes ensure that branches with names starting with "fix-" are correctly identified in the GitHub Actions environment, allowing the workflow to properly handle formatting-specific branches.