### PR TITLE
Fix regex pattern matching in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -103,10 +103,10 @@ jobs:
 
             # Use bash's native string operations for more consistent behavior across environments
             for kw in "${KEYWORDS[@]}"; do
-              # Case-insensitive substring check using bash parameter expansion
+              # Case-insensitive substring check using bash string contains operator
               # Explicitly print the comparison being made for debugging
               echo "Checking if '${BRANCH_NAME_LOWER}' contains '${kw}'"
-              if [[ "${BRANCH_NAME_LOWER}" =~ ${kw} ]]; then
+              if [[ "${BRANCH_NAME_LOWER}" == *"${kw}"* ]]; then
                 echo "Match found: branch contains keyword '${kw}'"
                 MATCHED_KEYWORD="${kw}"
                 MATCH_FOUND=true
@@ -123,7 +123,7 @@ jobs:
                 # Normalize keyword too for consistent comparison
                 NORMALIZED_KW=$(echo "${kw}" | tr -cd 'a-z0-9')
                 echo "Checking if normalized '${NORMALIZED_BRANCH}' contains '${NORMALIZED_KW}'"
-                if [[ "${NORMALIZED_BRANCH}" =~ ${NORMALIZED_KW} ]]; then
+                if [[ "${NORMALIZED_BRANCH}" == *"${NORMALIZED_KW}"* ]]; then
                   echo "Match found in normalized branch name: contains keyword '${kw}'"
                   MATCHED_KEYWORD="${kw} (normalized)"
                   MATCH_FOUND=true
@@ -135,7 +135,7 @@ jobs:
             if [[ "$MATCH_FOUND" != "true" ]]; then
               echo "Trying grep fallback method..."
               for kw in "${KEYWORDS[@]}"; do
-                if echo "${BRANCH_NAME_LOWER}" | grep -q ${kw}; then
+                if echo "${BRANCH_NAME_LOWER}" | grep -q -F "${kw}"; then
                   echo "Match found using grep: branch contains keyword '${kw}'"
                   MATCHED_KEYWORD="${kw} (grep)"
                   MATCH_FOUND=true

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -103,10 +103,10 @@ jobs:
 
             # Use bash's native string operations for more consistent behavior across environments
             for kw in "${KEYWORDS[@]}"; do
-              # Case-insensitive substring check using bash parameter expansion
+              # Case-insensitive substring check using bash string contains operator
               # Explicitly print the comparison being made for debugging
               echo "Checking if '${BRANCH_NAME_LOWER}' contains '${kw}'"
-              if [[ "${BRANCH_NAME_LOWER}" =~ ${kw} ]]; then
+              if [[ "${BRANCH_NAME_LOWER}" == *"${kw}"* ]]; then
                 echo "Match found: branch contains keyword '${kw}'"
                 MATCHED_KEYWORD="${kw}"
                 MATCH_FOUND=true
@@ -123,7 +123,7 @@ jobs:
                 # Normalize keyword too for consistent comparison
                 NORMALIZED_KW=$(echo "${kw}" | tr -cd 'a-z0-9')
                 echo "Checking if normalized '${NORMALIZED_BRANCH}' contains '${NORMALIZED_KW}'"
-                if [[ "${NORMALIZED_BRANCH}" =~ ${NORMALIZED_KW} ]]; then
+                if [[ "${NORMALIZED_BRANCH}" == *"${NORMALIZED_KW}"* ]]; then
                   echo "Match found in normalized branch name: contains keyword '${kw}'"
                   MATCHED_KEYWORD="${kw} (normalized)"
                   MATCH_FOUND=true
@@ -135,7 +135,7 @@ jobs:
             if [[ "$MATCH_FOUND" != "true" ]]; then
               echo "Trying grep fallback method..."
               for kw in "${KEYWORDS[@]}"; do
-                if echo "${BRANCH_NAME_LOWER}" | grep -q "${kw}"; then
+                if echo "${BRANCH_NAME_LOWER}" | grep -q ${kw}; then
                   echo "Match found using grep: branch contains keyword '${kw}'"
                   MATCHED_KEYWORD="${kw} (grep)"
                   MATCH_FOUND=true


### PR DESCRIPTION
This PR fixes the regex pattern matching issue in the pre-commit workflow.

## Root Cause
The workflow was failing because the bash regex pattern matching implementation was incorrectly handling the regex keyword in the branch name. When using the `=~` operator with unquoted variables, bash treats the right side as a regex pattern rather than a literal string to search for.

## Changes
1. Changed the pattern matching from using regex `=~` operator to using string contains operator `==` with wildcards `*"${kw}"*`
2. Updated the normalized branch check to use string contains operator
3. Added `-F` flag to grep to ensure it treats the pattern as a fixed string

These changes ensure that keywords like "regex" are properly matched in branch names, allowing the workflow to correctly identify branches that are fixing formatting issues.