### PR TITLE
Fix regex pattern matching in branch name detection

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,7 +1,7 @@
 name: pre-commit
 # This workflow runs pre-commit checks on all files and handles formatting-specific branches
-# The pattern matching logic has been improved to use native bash string operations instead of grep
-# for more consistent behavior across different environments (local vs GitHub Actions)
+# The pattern matching logic uses string contains operations instead of regex pattern matching
+# to avoid issues with regex special characters in keywords
 on:
   pull_request:
   push:
@@ -103,10 +103,10 @@ jobs:
 
             # Use bash's native string operations for more consistent behavior across environments
             for kw in "${KEYWORDS[@]}"; do
-              # Case-insensitive substring check using bash parameter expansion
-              # Explicitly print the comparison being made for debugging
+              # Case-insensitive substring check using string contains operator instead of regex
+              # This avoids issues with regex special characters in keywords
               echo "Checking if '${BRANCH_NAME_LOWER}' contains '${kw}'"
-              if [[ "${BRANCH_NAME_LOWER}" =~ ${kw} ]]; then
+              if [[ "${BRANCH_NAME_LOWER}" == *"${kw}"* ]]; then
                 echo "Match found: branch contains keyword '${kw}'"
                 MATCHED_KEYWORD="${kw}"
                 MATCH_FOUND=true
@@ -123,7 +123,7 @@ jobs:
                 # Normalize keyword too for consistent comparison
                 NORMALIZED_KW=$(echo "${kw}" | tr -cd 'a-z0-9')
                 echo "Checking if normalized '${NORMALIZED_BRANCH}' contains '${NORMALIZED_KW}'"
-                if [[ "${NORMALIZED_BRANCH}" =~ ${NORMALIZED_KW} ]]; then
+                if [[ "${NORMALIZED_BRANCH}" == *"${NORMALIZED_KW}"* ]]; then
                   echo "Match found in normalized branch name: contains keyword '${kw}'"
                   MATCHED_KEYWORD="${kw} (normalized)"
                   MATCH_FOUND=true
@@ -135,7 +135,7 @@ jobs:
             if [[ "$MATCH_FOUND" != "true" ]]; then
               echo "Trying grep fallback method..."
               for kw in "${KEYWORDS[@]}"; do
-                if echo "${BRANCH_NAME_LOWER}" | grep -q ${kw}; then
+                if echo "${BRANCH_NAME_LOWER}" | grep -F -q "${kw}"; then
                   echo "Match found using grep: branch contains keyword '${kw}'"
                   MATCHED_KEYWORD="${kw} (grep)"
                   MATCH_FOUND=true

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -103,10 +103,10 @@ jobs:
 
             # Use bash's native string operations for more consistent behavior across environments
             for kw in "${KEYWORDS[@]}"; do
-              # Case-insensitive substring check using bash parameter expansion
-              # Explicitly print the comparison being made for debugging
+              # Case-insensitive substring check using string contains operator instead of regex
+              # This avoids issues with regex special characters in keywords
               echo "Checking if '${BRANCH_NAME_LOWER}' contains '${kw}'"
-              if [[ "${BRANCH_NAME_LOWER}" =~ ${kw} ]]; then
+              if [[ "${BRANCH_NAME_LOWER}" == *"${kw}"* ]]; then
                 echo "Match found: branch contains keyword '${kw}'"
                 MATCHED_KEYWORD="${kw}"
                 MATCH_FOUND=true
@@ -123,7 +123,7 @@ jobs:
                 # Normalize keyword too for consistent comparison
                 NORMALIZED_KW=$(echo "${kw}" | tr -cd 'a-z0-9')
                 echo "Checking if normalized '${NORMALIZED_BRANCH}' contains '${NORMALIZED_KW}'"
-                if [[ "${NORMALIZED_BRANCH}" =~ ${NORMALIZED_KW} ]]; then
+                if [[ "${NORMALIZED_BRANCH}" == *"${NORMALIZED_KW}"* ]]; then
                   echo "Match found in normalized branch name: contains keyword '${kw}'"
                   MATCHED_KEYWORD="${kw} (normalized)"
                   MATCH_FOUND=true
@@ -135,7 +135,7 @@ jobs:
             if [[ "$MATCH_FOUND" != "true" ]]; then
               echo "Trying grep fallback method..."
               for kw in "${KEYWORDS[@]}"; do
-                if echo "${BRANCH_NAME_LOWER}" | grep -q "${kw}"; then
+                if echo "${BRANCH_NAME_LOWER}" | grep -F -q "${kw}"; then
                   echo "Match found using grep: branch contains keyword '${kw}'"
                   MATCHED_KEYWORD="${kw} (grep)"
                   MATCH_FOUND=true


### PR DESCRIPTION
This PR fixes the issue with regex pattern matching in the branch name detection logic in the pre-commit workflow.

## Root Cause
The workflow was using regex pattern matching (`=~` operator) with unquoted patterns, which caused special regex characters in keywords (like the `.` in "regex") to be interpreted as regex metacharacters rather than literal characters.

## Changes Made
1. Replaced regex pattern matching with string contains operations (`==` operator with `*` wildcards) to treat keywords as literal strings
2. Added the `-F` flag to grep to use fixed-string matching instead of regex pattern matching
3. Updated comments to reflect the changes

These changes ensure that keywords like "regex" are properly matched in branch names, allowing the workflow to correctly identify formatting fix branches.