### PR TITLE
Fix pattern matching in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -117,8 +117,9 @@ jobs:
               # Case-insensitive substring check using string contains operator instead of regex
               # This avoids issues with regex special characters in keywords
               echo "Checking if '${BRANCH_NAME_LOWER}' contains '${kw}'"
-              # Use a more explicit string comparison with fixed strings
-              if [[ "${BRANCH_NAME_LOWER}" =~ "${kw}" ]]; then
+              # Note: When using =~ operator, the pattern should NOT be quoted
+              # Using unquoted pattern to ensure proper regex matching
+              if [[ "${BRANCH_NAME_LOWER}" =~ ${kw} ]]; then
                 echo "Match found: branch contains keyword '${kw}'"
                 MATCHED_KEYWORD="${kw}"
                 MATCH_FOUND=true
@@ -135,7 +136,8 @@ jobs:
                 # Normalize keyword too for consistent comparison
                 NORMALIZED_KW=$(echo "${kw}" | tr -cd 'a-z0-9')
                 echo "Checking if normalized '${NORMALIZED_BRANCH}' contains '${NORMALIZED_KW}'"
-                if [[ "${NORMALIZED_BRANCH}" =~ "${NORMALIZED_KW}" ]]; then
+                # Note: When using =~ operator, the pattern should NOT be quoted
+                if [[ "${NORMALIZED_BRANCH}" =~ ${NORMALIZED_KW} ]]; then
                   echo "Match found in normalized branch name: contains keyword '${kw}'"
                   MATCHED_KEYWORD="${kw} (normalized)"
                   MATCH_FOUND=true

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -69,6 +69,10 @@ jobs:
             char="${BRANCH_NAME:$i:1}"
             printf "Position %d: %s (ASCII: %d)\n" "$i" "$char" "'$char"
           done
+          
+          # Additional debug: hexdump of branch name to detect any invisible characters
+          echo "Hexdump of branch name:"
+          echo -n "${BRANCH_NAME}" | hexdump -C
 
           # Check if we're on a branch specifically fixing formatting issues
           # Using string contains operator for substring matching anywhere in the branch name
@@ -113,8 +117,9 @@ jobs:
               # Case-insensitive substring check using string contains operator instead of regex
               # This avoids issues with regex special characters in keywords
               echo "Checking if '${BRANCH_NAME_LOWER}' contains '${kw}'"
-              # Use a more explicit string comparison with fixed strings
-              if [[ "${BRANCH_NAME_LOWER}" =~ "${kw}" ]]; then
+              # Note: When using =~ operator, the pattern should NOT be quoted
+              # Using unquoted pattern to ensure proper regex matching
+              if [[ "${BRANCH_NAME_LOWER}" =~ ${kw} ]]; then
                 echo "Match found: branch contains keyword '${kw}'"
                 MATCHED_KEYWORD="${kw}"
                 MATCH_FOUND=true
@@ -131,7 +136,7 @@ jobs:
                 # Normalize keyword too for consistent comparison
                 NORMALIZED_KW=$(echo "${kw}" | tr -cd 'a-z0-9')
                 echo "Checking if normalized '${NORMALIZED_BRANCH}' contains '${NORMALIZED_KW}'"
-                if [[ "${NORMALIZED_BRANCH}" =~ "${NORMALIZED_KW}" ]]; then
+                if [[ "${NORMALIZED_BRANCH}" =~ ${NORMALIZED_KW} ]]; then
                   echo "Match found in normalized branch name: contains keyword '${kw}'"
                   MATCHED_KEYWORD="${kw} (normalized)"
                   MATCH_FOUND=true


### PR DESCRIPTION
This PR fixes the pattern matching issue in the pre-commit workflow.

## Root Cause
The issue was in the pattern matching logic of the pre-commit workflow. When using the `=~` operator in Bash, the right-hand side is treated as a regex pattern. However, when the pattern is enclosed in quotes (`"${kw}"`), it's treated as a literal string match rather than a regex pattern. This caused the pattern matching to fail because it was looking for an exact match of the entire string rather than a substring.

## Solution
The fix removes the quotes around the regex patterns in the `=~` operator:
- Changed `if [[ "${BRANCH_NAME_LOWER}" =~ "${kw}" ]]` to `if [[ "${BRANCH_NAME_LOWER}" =~ ${kw} ]]`
- Changed `if [[ "${NORMALIZED_BRANCH}" =~ "${NORMALIZED_KW}" ]]` to `if [[ "${NORMALIZED_BRANCH}" =~ ${NORMALIZED_KW} ]]`
- Added comments to explain the proper usage of the `=~` operator

This change ensures that the pattern matching works correctly and will properly detect keywords in branch names.