### PR TITLE
Fix workflow failure by properly handling pipefail and exit codes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -243,20 +243,26 @@ jobs:
         run: |
           # Debug output to verify the condition
           echo "Debug: is_formatting_fix value from previous step: '${{ steps.check_formatting_branch.outputs.is_formatting_fix }}'"
-          set -o pipefail
+          
           # Clean pre-commit cache to remove phantom files
           pre-commit clean
           pre-commit gc
           # Remove any existing log file and create a new empty one
           rm -f ${RAW_LOG}
           touch ${RAW_LOG}
-          # Run pre-commit on all files in check-only mode and ensure output is captured
+          
+          # Run pre-commit and capture its output to the log file
+          # Store the exit code separately to prevent it from affecting the workflow
           pre-commit run --show-diff-on-failure --color=always --all-files -c .pre-commit-config-ci.yaml | tee ${RAW_LOG}
-
+          # Capture the exit code using PIPESTATUS which preserves the exit code of the first command in the pipe
+          PRE_COMMIT_EXIT_CODE=${PIPESTATUS[0]}
+          
+          # Log the exit code for debugging
+          echo "Pre-commit exit code: ${PRE_COMMIT_EXIT_CODE}"
+          
           # Log that we're skipping validation for formatting fix branch
           echo "::warning::Skipping pre-commit validation for formatting fix branch"
-          # Always exit with success for formatting fix branches regardless of pre-commit exit code
-          exit 0
+          
           # Always exit with success for formatting fix branches regardless of pre-commit exit code
           exit 0
       - name: Convert Raw Log to Checkstyle format (launch action)

--- a/.github/workflows/pre-commit.yml.bak
+++ b/.github/workflows/pre-commit.yml.bak
@@ -182,8 +182,12 @@ jobs:
           fi
 
           # Set output for use in subsequent steps
-          # Fix: Use the correct GitHub Actions output syntax
-          echo "is_formatting_fix=${IS_FORMATTING_FIX}" >> $GITHUB_OUTPUT
+          # Fix: Use the correct GitHub Actions output syntax for GitHub Actions runner v2
+          if [[ "$IS_FORMATTING_FIX" == "true" ]]; then
+            echo "is_formatting_fix=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_formatting_fix=false" >> $GITHUB_OUTPUT
+          fi
           # Debug output to verify the value is being set correctly
           echo "Debug: Setting is_formatting_fix output to '${IS_FORMATTING_FIX}'"
 
@@ -239,20 +243,27 @@ jobs:
         run: |
           # Debug output to verify the condition
           echo "Debug: is_formatting_fix value from previous step: '${{ steps.check_formatting_branch.outputs.is_formatting_fix }}'"
-          set -o pipefail
+          
           # Clean pre-commit cache to remove phantom files
           pre-commit clean
           pre-commit gc
           # Remove any existing log file and create a new empty one
           rm -f ${RAW_LOG}
           touch ${RAW_LOG}
-          # Run pre-commit on all files in check-only mode and ensure output is captured
-          pre-commit run --show-diff-on-failure --color=always --all-files -c .pre-commit-config-ci.yaml | tee ${RAW_LOG}
-
+          
+          # Run pre-commit without pipefail to prevent pipeline exit code from failing the workflow
+          # Use a separate command to capture the output to the log file
+          pre-commit run --show-diff-on-failure --color=always --all-files -c .pre-commit-config-ci.yaml > >(tee ${RAW_LOG})
+          
+          # Capture the exit code explicitly
+          PRE_COMMIT_EXIT_CODE=$?
+          
+          # Log the exit code for debugging
+          echo "Pre-commit exit code: ${PRE_COMMIT_EXIT_CODE}"
+          
           # Log that we're skipping validation for formatting fix branch
           echo "::warning::Skipping pre-commit validation for formatting fix branch"
-          # Always exit with success for formatting fix branches regardless of pre-commit exit code
-          exit 0
+          
           # Always exit with success for formatting fix branches regardless of pre-commit exit code
           exit 0
       - name: Convert Raw Log to Checkstyle format (launch action)


### PR DESCRIPTION
This PR fixes the issue with the pre-commit workflow failing for formatting fix branches.

## Root Cause
The `set -o pipefail` option in the shell script was causing the workflow to fail despite the `exit 0` commands at the end of the script. When `set -o pipefail` is enabled, it causes the pipeline to return the exit status of the last command to exit with a non-zero status. The pre-commit run command was failing with a non-zero exit code, and because of `pipefail`, this exit code was propagated to the entire pipeline despite the `tee` command succeeding.

## Solution
1. Removed the `set -o pipefail` directive
2. Added explicit capture of the pre-commit exit code using `${PIPESTATUS[0]}`
3. Added logging of the exit code for debugging purposes
4. Ensured the script always exits with code 0 for formatting fix branches

This change ensures that even when pre-commit fails, the workflow will still succeed for formatting fix branches as intended.